### PR TITLE
Separate files and update test manifest for double value matching on 0e0 vs 0E0

### DIFF
--- a/validation/Is1_Ip1_DBL0E0UC.ttl
+++ b/validation/Is1_Ip1_DBL0E0UC.ttl
@@ -1,0 +1,1 @@
+<http://a.example/s1>  <http://a.example/p1> 0E0 .

--- a/validation/Is1_Ip1_DBL0e0.ttl
+++ b/validation/Is1_Ip1_DBL0e0.ttl
@@ -1,1 +1,1 @@
-<http://a.example/s1>  <http://a.example/p1> 0E0 .
+<http://a.example/s1>  <http://a.example/p1> 0e0 .

--- a/validation/manifest.jsonld
+++ b/validation/manifest.jsonld
@@ -1842,8 +1842,8 @@
           "status": "mf:proposed"
         },
         {
-          "@id": "#1val1DOUBLE_pass",
-          "@type": "sht:ValidationTest",
+          "@id": "#1val1DOUBLE_fail",
+          "@type": "sht:ValidationFailure",
           "action": {
             "schema": "../schemas/1val1DOUBLE.shex",
             "shape": "http://a.example/S1",
@@ -1851,13 +1851,12 @@
             "focus": "http://a.example/s1"
           },
           "extensionResults": [],
-          "name": "1val1DOUBLE_pass",
+          "name": "1val1DOUBLE_fail",
           "trait": [
             "NumericEquivalence"
           ],
-          "comment": "<S1> { <p1> [0e0] } on { <s> <p1> 0e0 }",
-          "status": "mf:proposed",
-          "result": "1val1DOUBLE_pass.val"
+          "comment": "<S1> { <p1> [0E0] } on { <s> <p1> 0e0 }",
+          "status": "mf:proposed"
         },
         {
           "@id": "#1val1DOUBLE_passUC",
@@ -1865,7 +1864,7 @@
           "action": {
             "schema": "../schemas/1val1DOUBLE.shex",
             "shape": "http://a.example/S1",
-            "data": "Is1_Ip1_DBL0e0.ttl",
+            "data": "Is1_Ip1_DBL0E0UC.ttl",
             "focus": "http://a.example/s1"
           },
           "extensionResults": [],
@@ -1873,7 +1872,7 @@
           "trait": [
             "NumericEquivalence"
           ],
-          "comment": "<S> { <p1> [0e0] } on { <s> <p1> 0E0 }",
+          "comment": "<S> { <p1> [0E0] } on { <s> <p1> 0E0 }",
           "status": "mf:proposed",
           "result": "1val1DOUBLE_pass.val"
         },
@@ -1891,7 +1890,7 @@
           "trait": [
             "NumericEquivalence"
           ],
-          "comment": "<S> { <p1> [0e0] } on { <s> <p1> 0e0.0 }",
+          "comment": "<S> { <p1> [0E0] } on { <s> <p1> 0e0.0 }",
           "status": "mf:proposed"
         },
         {
@@ -1913,22 +1912,21 @@
           "result": "1val1DOUBLE_pass.val"
         },
         {
-          "@id": "#1val1DOUBLElowercase_passUC",
-          "@type": "sht:ValidationTest",
+          "@id": "#1val1DOUBLElowercase_failUC",
+          "@type": "sht:ValidationFailure",
           "action": {
             "schema": "../schemas/1val1DOUBLElowercase.shex",
             "shape": "http://a.example/S1",
-            "data": "Is1_Ip1_DBL0e0.ttl",
+            "data": "Is1_Ip1_DBL0E0UC.ttl",
             "focus": "http://a.example/s1"
           },
           "extensionResults": [],
-          "name": "1val1DOUBLElowercase_passUC",
+          "name": "1val1DOUBLElowercase_failUC",
           "trait": [
             "NumericEquivalence"
           ],
           "comment": "<S> { <p1> [0e0] } on { <s> <p1> 0E0 }",
-          "status": "mf:proposed",
-          "result": "1val1DOUBLE_pass.val"
+          "status": "mf:proposed"
         },
         {
           "@id": "#1val1DOUBLElowercase_0_0e0",

--- a/validation/manifest.ttl
+++ b/validation/manifest.ttl
@@ -139,13 +139,13 @@
         <#1val1INTEGER_pass>            # <S> { <p1> [0] }
         <#1val1INTEGER_00>
         <#1val1INTEGER_Lab>
-        <#1val1DOUBLE_pass>             # <S> { <p1> [0e0] }
+        <#1val1DOUBLE_fail>             # <S> { <p1> [0e0] }
         <#1val1DOUBLE_passUC>
         <#1val1DOUBLE_0_0e0>
         # 1val1DOUBLElowercase_... same as 1val1DOUBLE
         # @@ eliminate as duplicate?
         <#1val1DOUBLElowercase_pass>    # <S> { <p1> [0e0] }
-        <#1val1DOUBLElowercase_passUC>
+        <#1val1DOUBLElowercase_failUC>
         <#1val1DOUBLElowercase_0_0e0>
 
 ####     language tag equivalence
@@ -2323,10 +2323,10 @@
     ] ;
     .
 
-<#1val1DOUBLE_pass> a sht:ValidationTest ;
-    mf:name "1val1DOUBLE_pass" ;
+<#1val1DOUBLE_fail> a sht:ValidationFailure ;
+    mf:name "1val1DOUBLE_fail" ;
     sht:trait sht:NumericEquivalence ;
-    rdfs:comment "<S1> { <p1> [0e0] } on { <s> <p1> 0e0 }" ;
+    rdfs:comment "<S1> { <p1> [0E0] } on { <s> <p1> 0e0 }" ;
     mf:status mf:proposed ;
     mf:action [
       sht:schema <../schemas/1val1DOUBLE.shex> ;
@@ -2334,18 +2334,17 @@
       sht:data <Is1_Ip1_DBL0e0.ttl> ;
       sht:focus <http://a.example/s1>
     ] ;
-    mf:result <1val1DOUBLE_pass.val>
     .
 
 <#1val1DOUBLE_passUC> a sht:ValidationTest ;
     mf:name "1val1DOUBLE_passUC" ;
     sht:trait sht:NumericEquivalence ;
-    rdfs:comment "<S> { <p1> [0e0] } on { <s> <p1> 0E0 }" ;
+    rdfs:comment "<S> { <p1> [0E0] } on { <s> <p1> 0E0 }" ;
     mf:status mf:proposed ;
     mf:action [
       sht:schema <../schemas/1val1DOUBLE.shex> ;
       sht:shape <http://a.example/S1> ;
-      sht:data <Is1_Ip1_DBL0e0.ttl> ;
+      sht:data <Is1_Ip1_DBL0E0UC.ttl> ;
       sht:focus <http://a.example/s1>
     ] ;
     mf:result <1val1DOUBLE_pass.val>
@@ -2354,7 +2353,7 @@
 <#1val1DOUBLE_0_0e0> a sht:ValidationFailure ;
     mf:name "1val1DOUBLE_0_0e0" ;
     sht:trait sht:NumericEquivalence ;
-    rdfs:comment "<S> { <p1> [0e0] } on { <s> <p1> 0e0.0 }" ;
+    rdfs:comment "<S> { <p1> [0E0] } on { <s> <p1> 0e0.0 }" ;
     mf:status mf:proposed ;
     mf:action [
       sht:schema <../schemas/1val1DOUBLE.shex> ;
@@ -2378,18 +2377,17 @@
     mf:result <1val1DOUBLE_pass.val>
     .
 
-<#1val1DOUBLElowercase_passUC> a sht:ValidationTest ;
-    mf:name "1val1DOUBLElowercase_passUC" ;
+<#1val1DOUBLElowercase_failUC> a sht:ValidationFailure ;
+    mf:name "1val1DOUBLElowercase_failUC" ;
     sht:trait sht:NumericEquivalence ;
     rdfs:comment "<S> { <p1> [0e0] } on { <s> <p1> 0E0 }" ;
     mf:status mf:proposed ;
     mf:action [
       sht:schema <../schemas/1val1DOUBLElowercase.shex> ;
       sht:shape <http://a.example/S1> ;
-      sht:data <Is1_Ip1_DBL0e0.ttl> ;
+      sht:data <Is1_Ip1_DBL0E0UC.ttl> ;
       sht:focus <http://a.example/s1>
     ] ;
-    mf:result <1val1DOUBLE_pass.val>
     .
 
 <#1val1DOUBLElowercase_0_0e0> a sht:ValidationFailure ;


### PR DESCRIPTION
Add Is1_Ip1_DBL0E0UC.ttl with object value 0E0.
Change 1val1DOUBLE_pass to 1val1DOUBLE_fail .
Use Is1_Ip1_DBL0E0UC.ttl in 1val1DOUBLE_passUC.
Change 1val1DOUBLElowercase_passUC to 1val1DOUBLElowercase_failUC and use Is1_Ip1_DBL0E0UC.ttl.