### PR TITLE
merge main into extends

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,39 @@
+This work is being provided by the copyright holders under the following license.
+
+License
+
+By obtaining and/or copying this work, you (the licensee) agree that you have
+read, understood, and will comply with the following terms and conditions.
+
+Permission to copy, modify, and distribute this work, with or without
+modification, for any purpose and without fee or royalty is hereby granted,
+provided that you include the following on ALL copies of the work or portions
+thereof, including modifications:
+
+  * The full text of this NOTICE in a location viewable to users of the
+    redistributed or derivative work.
+
+  * Any pre-existing intellectual property disclaimers, notices, or terms and
+    conditions. If none exist, the W3C Software and Document Short Notice should be
+    included.
+
+  * Notice of any changes or modifications, through a copyright statement on the
+    new code or document such as "This software or document includes material
+    copied from or derived from [title and URI of the W3C document]. Copyright ©
+    [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
+
+Disclaimers
+
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR
+WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF
+MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE
+SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
+TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+The name and trademarks of copyright holders may NOT be used in advertising or
+publicity pertaining to the work without specific, written prior
+permission. Title to copyright in this work will at all times remain with
+copyright holders.

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ negativeStructure/manifest.jsonld: negativeStructure/manifest.ttl
 ShExTests: ShExJTests ShExVTests
 
 ShExJTests: doc/ShExJ.jsg
-	(ls schemas/*.json | grep -v coverage.json | xargs \
+	(ls schemas/*.json | grep -vE '(coverage|representationTests)\.json' | xargs \
 	 `npm bin`/json-grammar doc/ShExJ.jsg)
 
 ShExVTests: doc/ShExV.jsg

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ These tests should raise errors when parsed, noting the rule about nested `Value
 
 ### `validation`
 
-* Validation tests in a manifest (Turtle - `manifest.ttl`, [ShExJ][http://shex.io/shex-primer/ShExJ) - `manifest.json`).
+* Validation tests in a manifest (Turtle - `manifest.ttl`, [ShExJ](http://shex.io/shex-semantics/#shexj) ([obselete primer](http://shex.io/shex-primer-20170327/ShExJ)) - `manifest.json`).
 * Input data in Turtle (`.ttl`).
-* [ShEx Results format](http://shex.io/shex-primer/ShExJ) (`.val`).
+* Validation returns a [ShapeMap](https://shexspec.github.io/shape-map/) capturing which node/shape pairs conform. The expected conformance or non-conformance is captured in the test format as a `ValidationTest` or `ValidationFailure`. 
 
 A ShEx validator is `logic-conformant` when it returns success for the tests of type `ValidationTest` and failure for the tests of type `ValidationFailure`.
 A ShEx validator is `result-conformant` (experimental) when it executes as `ValidationTest` and produces the same result structure as produced by this procedure:

--- a/doc/ShExJ-context.jsonld
+++ b/doc/ShExJ-context.jsonld
@@ -1,0 +1,190 @@
+{
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "shex": "http://www.w3.org/ns/shex#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "annotations": {
+      "@id": "shex:annotation",
+      "@container": "@list",
+      "@type": "@id"
+    },
+    "exclusions": {
+      "@id": "shex:exclusion",
+      "@container": "@list",
+      "@type": "@id"
+    },
+    "id": "@id",
+    "language": "@language",
+    "type": "@type",
+    "value": "@value",
+    "Annotation": "shex:Annotation",
+    "EachOf": "shex:EachOf",
+    "IriStem": "shex:IriStem",
+    "IriStemRange": "shex:IriStemRange",
+    "Language": "shex:Language",
+    "LanguageStem": "shex:LanguageStem",
+    "LanguageStemRange": "shex:LanguageStemRange",
+    "LiteralStem": "shex:LiteralStem",
+    "LiteralStemRange": "shex:LiteralStemRange",
+    "NodeConstraint": "shex:NodeConstraint",
+    "OneOf": "shex:OneOf",
+    "Schema": "shex:Schema",
+    "SemAct": "shex:SemAct",
+    "Shape": "shex:Shape",
+    "ShapeAnd": "shex:ShapeAnd",
+    "ShapeExternal": "shex:ShapeExternal",
+    "ShapeNot": "shex:ShapeNot",
+    "ShapeOr": "shex:ShapeOr",
+    "Stem": "shex:Stem",
+    "StemRange": "shex:StemRange",
+    "TripleConstraint": "shex:TripleConstraint",
+    "Wildcard": "shex:Wildcard",
+    "closed": {
+      "@id": "shex:closed",
+      "@type": "xsd:boolean"
+    },
+    "code": {
+      "@id": "shex:code",
+      "@language": null
+    },
+    "datatype": {
+      "@id": "shex:datatype",
+      "@type": "@id"
+    },
+    "expression": {
+      "@id": "shex:expression",
+      "@type": "@id"
+    },
+    "expressions": {
+      "@id": "shex:expressions",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "extra": {
+      "@id": "shex:extra",
+      "@type": "@id"
+    },
+    "flags": {
+      "@id": "shex:flags",
+      "@language": null
+    },
+    "fractiondigits": {
+      "@id": "shex:fractiondigits",
+      "@type": "xsd:integer"
+    },
+    "inverse": {
+      "@id": "shex:inverse",
+      "@type": "xsd:boolean"
+    },
+    "languageTag": {
+      "@id": "shex:languageTag",
+      "@language": null
+    },
+    "length": {
+      "@id": "shex:length",
+      "@type": "xsd:integer"
+    },
+    "max": {
+      "@id": "shex:max",
+      "@type": "xsd:integer"
+    },
+    "maxexclusive": {
+      "@id": "shex:maxexclusive",
+      "@type": "xsd:integer"
+    },
+    "maxinclusive": {
+      "@id": "shex:maxinclusive",
+      "@type": "xsd:integer"
+    },
+    "maxlength": {
+      "@id": "shex:maxlength",
+      "@type": "xsd:integer"
+    },
+    "min": {
+      "@id": "shex:min",
+      "@type": "xsd:integer"
+    },
+    "minexclusive": {
+      "@id": "shex:minexclusive",
+      "@type": "xsd:integer"
+    },
+    "mininclusive": {
+      "@id": "shex:mininclusive",
+      "@type": "xsd:integer"
+    },
+    "minlength": {
+      "@id": "shex:minlength",
+      "@type": "xsd:integer"
+    },
+    "name": {
+      "@id": "shex:name",
+      "@type": "@id"
+    },
+    "nodeKind": {
+      "@id": "shex:nodeKind",
+      "@type": "@vocab"
+    },
+    "object": {
+      "@id": "shex:object",
+      "@type": "@id"
+    },
+    "pattern": {
+      "@id": "shex:pattern",
+      "@language": null
+    },
+    "predicate": {
+      "@id": "shex:predicate",
+      "@type": "@id"
+    },
+    "semActs": {
+      "@id": "shex:semActs",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "shapeExpr": {
+      "@id": "shex:shapeExpr",
+      "@type": "@id"
+    },
+    "shapeExprs": {
+      "@id": "shex:shapeExprs",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "shapes": {
+      "@id": "shex:shapes",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "start": {
+      "@id": "shex:start",
+      "@type": "@id"
+    },
+    "startActs": {
+      "@id": "shex:startActs",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "stem": {
+      "@id": "shex:stem",
+      "@type": "xsd:string"
+    },
+    "totaldigits": {
+      "@id": "shex:totaldigits",
+      "@type": "xsd:integer"
+    },
+    "valueExpr": {
+      "@id": "shex:valueExpr",
+      "@type": "@id"
+    },
+    "values": {
+      "@id": "shex:values",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "bnode": "shex:bnode",
+    "iri": "shex:iri",
+    "literal": "shex:literal",
+    "nonliteral": "shex:nonliteral"
+  }
+}

--- a/doc/ShExMan.jsonld
+++ b/doc/ShExMan.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context":{
+    "@version": 1.1 ,
+    "shex": "http://www.w3.org/2013/ShEx/ns#",
+    "shexman": "http://www.w3.org/2013/ShEx/manifest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+
+    "type": { "@id": "rdf:type", "@type": "@id" },
+    "entries": {"@id": "shexman:entries", "@container": "@list"},
+    "title": "shexman:title",
+    "desc": "shexman:desc" ,
+    "shapePath": "shexman:shapePath" ,
+    "shapePathDataMatch": "shexman:shapePathDataMatch" ,
+    "shexTest": "shexman:shexTest" ,
+    "status": "shexman:status",
+    "shapePathSchemaMatch": {
+      "@id": "shexman:shapePathSchemaMatch",
+      "@context": "http://www.w3.org/ns/shex.jsonld"
+    },
+    "value": "shexman:value"   
+  }
+}

--- a/doc/ShExR.shex
+++ b/doc/ShExR.shex
@@ -6,10 +6,10 @@ start=@<Schema>
 
 <Schema> CLOSED {
   a [sx:Schema] ;
-  sx:imports @<IriList1Plus>? ;
-  sx:startActs @<SemActList1Plus>? ;
-  sx:start @<shapeExpr>? ;
-  sx:shapes @<shapeDeclOrExpr>*
+  sx:imports @<IriList1Plus> ? ;
+  sx:startActs @<SemActList1Plus> ? ;
+  sx:start @<shapeExpr> ? ;
+  sx:shapes @<shapeDeclOrExprList1Plus> ?
 }
 
 # <shapeDeclOrExpr> is a shortcut for always requriing a ShapeDecl
@@ -40,30 +40,30 @@ start=@<Schema>
 
 <NodeConstraint> CLOSED {
   a [sx:NodeConstraint] ;
-  sx:nodeKind [sx:iri sx:bnode sx:literal sx:nonliteral]?;
+  sx:nodeKind [sx:iri sx:bnode sx:literal sx:nonliteral] ? ;
   sx:datatype IRI ? ;
   &<xsFacets>  ;
-  sx:values @<valueSetValueList1Plus>?
+  sx:values @<valueSetValueList1Plus> ?
 }
 
 <Shape> CLOSED {
   a [sx:Shape] ;
   sx:extends @<shapeDeclOrExprList1Plus>? ;
-  sx:closed [true false]? ;
-  sx:extra IRI* ;
-  sx:expression @<tripleExpression>? ;
-  sx:semActs @<SemActList1Plus>? ;
-  sx:annotation @<AnnotationList1Plus>? ;
+  sx:closed [true false] ? ;
+  sx:extra IRI * ;
+  sx:expression @<tripleExpression> ? ;
+  sx:semActs @<SemActList1Plus> ? ;
+  sx:annotation @<AnnotationList1Plus> ?
 }
 
 <ShapeExternal> CLOSED {
-  a [sx:ShapeExternal] ;
+  a [sx:ShapeExternal]
 }
 
 <SemAct> CLOSED {
   a [sx:SemAct] ;
   sx:name IRI ;
-  sx:code xsd:string?
+  sx:code xsd:string ?
 }
 
 <Annotation> CLOSED {
@@ -74,13 +74,13 @@ start=@<Schema>
 
 # <xsFacet> @<stringFacet> OR @<numericFacet>
 <facet_holder> { # hold labeled productions
-  $<xsFacets> ( &<stringFacet> | &<numericFacet> )* ;
+  $<xsFacets> ( &<stringFacet> | &<numericFacet> ) * ;
   $<stringFacet> (
       sx:length xsd:integer
     | sx:minlength xsd:integer
     | sx:maxlength xsd:integer
-    | sx:pattern xsd:string ; sx:flags xsd:string?
-  );
+    | sx:pattern xsd:string ; sx:flags xsd:string ?
+  ) ;
   $<numericFacet> (
       sx:mininclusive   @<numericLiteral>
     | sx:minexclusive   @<numericLiteral>
@@ -96,23 +96,23 @@ start=@<Schema>
                                OR @<LiteralStem> OR @<LiteralStemRange>
                 OR @<Language> OR @<LanguageStem> OR @<LanguageStemRange>
 <objectValue> IRI OR LITERAL # rdf:langString breaks on Annotation.object
-<Language> CLOSED { a [sx:Language]; sx:languageTag xsd:string }
-<IriStem> CLOSED { a [sx:IriStem]; sx:stem xsd:string }
+<Language> CLOSED { a [sx:Language] ; sx:languageTag xsd:string }
+<IriStem> CLOSED { a [sx:IriStem] ; sx:stem xsd:string }
 <IriStemRange> CLOSED {
-  a [sx:IriStemRange];
-  sx:stem xsd:string OR @<Wildcard>;
+  a [sx:IriStemRange] ;
+  sx:stem xsd:string OR @<Wildcard> ;
   sx:exclusion @<IriStemExclusionList1Plus>
 }
-<LiteralStem> CLOSED { a [sx:LiteralStem]; sx:stem xsd:string }
+<LiteralStem> CLOSED { a [sx:LiteralStem] ; sx:stem xsd:string }
 <LiteralStemRange> CLOSED {
-  a [sx:LiteralStemRange];
-  sx:stem xsd:string OR @<Wildcard>;
+  a [sx:LiteralStemRange] ;
+  sx:stem xsd:string OR @<Wildcard> ;
   sx:exclusion @<LiteralStemExclusionList1Plus>
 }
-<LanguageStem> CLOSED { a [sx:LanguageStem]; sx:stem xsd:string }
+<LanguageStem> CLOSED { a [sx:LanguageStem] ; sx:stem xsd:string }
 <LanguageStemRange> CLOSED {
-  a [sx:LanguageStemRange];
-  sx:stem xsd:string OR @<Wildcard>;
+  a [sx:LanguageStemRange] ;
+  sx:stem xsd:string OR @<Wildcard> ;
   sx:exclusion @<LanguageStemExclusionList1Plus>
 }
 <Wildcard> BNODE CLOSED {
@@ -123,20 +123,20 @@ start=@<Schema>
 
 <OneOf> CLOSED {
   a [sx:OneOf] ;
-  sx:min xsd:integer? ;
-  sx:max xsd:integer? ;
+  sx:min xsd:integer ? ;
+  sx:max xsd:integer ? ;
   sx:expressions @<tripleExpressionList2Plus> ;
-  sx:semActs @<SemActList1Plus>? ;
-  sx:annotation @<AnnotationList1Plus>?
+  sx:semActs @<SemActList1Plus> ? ;
+  sx:annotation @<AnnotationList1Plus> ?
 }
 
 <EachOf> CLOSED {
   a [sx:EachOf] ;
-  sx:min xsd:integer? ;
-  sx:max xsd:integer? ;
+  sx:min xsd:integer ? ;
+  sx:max xsd:integer ? ;
   sx:expressions @<tripleExpressionList2Plus> ;
-  sx:semActs @<SemActList1Plus>? ;
-  sx:annotation @<AnnotationList1Plus>?
+  sx:semActs @<SemActList1Plus> ? ;
+  sx:annotation @<AnnotationList1Plus> ?
 }
 
 <tripleExpressionList2Plus> CLOSED {
@@ -150,14 +150,14 @@ start=@<Schema>
 
 <TripleConstraint> CLOSED {
   a [sx:TripleConstraint] ;
-  sx:inverse [true false]? ;
-  sx:negated [true false]? ;
-  sx:min xsd:integer? ;
-  sx:max xsd:integer? ;
+  sx:inverse [true false] ? ;
+  sx:negated [true false] ? ;
+  sx:min xsd:integer ? ;
+  sx:max xsd:integer ? ;
   sx:predicate IRI ;
-  sx:valueExpr @<shapeDeclOrExpr>? ;
-  sx:semActs @<SemActList1Plus>? ;
-  sx:annotation @<AnnotationList1Plus>?
+  sx:valueExpr @<shapeDeclOrExpr> ? ;
+  sx:semActs @<SemActList1Plus> ? ;
+  sx:annotation @<AnnotationList1Plus> ?
 }
 
 <IriList1Plus> CLOSED {

--- a/doc/ShExR.ttl
+++ b/doc/ShExR.ttl
@@ -44,7 +44,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
       [ a sx:TripleConstraint ; sx:predicate sx:start ; sx:min 0 ; sx:max 1 ;
         sx:valueExpr <shapeExpr> ]
       [ a sx:TripleConstraint ; sx:predicate sx:shapes ; sx:min 0 ; sx:max -1 ;
-        sx:valueExpr <shapeExpr> ] ) ] .
+        sx:valueExpr <shapeExprList1Plus> ] ) ] .
 
 <shapeExpr> a sx:ShapeOr ;
   sx:shapeExprs ( <ShapeOr> <ShapeAnd> <ShapeNot> <NodeConstraint> <Shape> <ShapeExternal> ) .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shex-test",
-  "version": "2.0.3",
+  "version": "2.1.1",
   "description": "Shape Expressions library tests.",
   "scripts": {
     "dist": "for d in schemas/ negativeSyntax/ negativeStructure/ validation/; do (cd $d && make); done",
@@ -27,6 +27,7 @@
     "n3": "^0.4.5",
     "xlsx": "^0.8.0"
   },
+  "postpublish" : "PACKAGE_VERSION=$(cat package.json | grep \\\"version\\\" | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]') && git tag v$PACKAGE_VERSION && git push --tags",
   "file": [
     "schemas",
     "negativeSyntax",

--- a/schemas/0.ttl
+++ b/schemas/0.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape .
 

--- a/schemas/0Extends1.ttl
+++ b/schemas/0Extends1.ttl
@@ -3,8 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+  sx:shapes (<http://a.example/S1> <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/0focusBNODE.ttl
+++ b/schemas/0focusBNODE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs (

--- a/schemas/0focusIRI.ttl
+++ b/schemas/0focusIRI.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs (

--- a/schemas/1Adot.ttl
+++ b/schemas/1Adot.ttl
@@ -4,7 +4,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1IRIInline0.ttl
+++ b/schemas/1IRIInline0.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/1IRI_with_UCHAR.1dot.ttl
+++ b/schemas/1IRI_with_UCHAR.1dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1IRI_with_all_punctuationdot.ttl
+++ b/schemas/1IRI_with_all_punctuationdot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1Include1-after.ttl
+++ b/schemas/1Include1-after.ttl
@@ -2,7 +2,7 @@ BASE <http://all.example/>
 PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
-  sx:shapes <S1>, <S2> .
+  sx:shapes (<S1> <S2>) .
 
 <S1> a sx:Shape ;
   sx:expression <S2e> .

--- a/schemas/1Include1.ttl
+++ b/schemas/1Include1.ttl
@@ -2,7 +2,7 @@ BASE <http://all.example/>
 PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
-  sx:shapes <S1>, <S2> .
+  sx:shapes (<S1> <S2>) .
 
 <S1> a sx:Shape ;
   sx:expression <S2e> .

--- a/schemas/1Length.ttl
+++ b/schemas/1Length.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1NOTIRI.ttl
+++ b/schemas/1NOTIRI.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOTNOTIRI.ttl
+++ b/schemas/1NOTNOTIRI.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOTNOTdot.ttl
+++ b/schemas/1NOTNOTdot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOTNOTvs.ttl
+++ b/schemas/1NOTNOTvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOTRefOR1dot.ttl
+++ b/schemas/1NOTRefOR1dot.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>, <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1> <http://a.example/S2>) .
 
 <http://a.example/S1>a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1NOT_literalANDvs_.ttl
+++ b/schemas/1NOT_literalANDvs_.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOT_literalORvs_.ttl
+++ b/schemas/1NOT_literalORvs_.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOT_vsANDvs_.ttl
+++ b/schemas/1NOT_vsANDvs_.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOT_vsORvs_.ttl
+++ b/schemas/1NOT_vsORvs_.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOTdot.ttl
+++ b/schemas/1NOTdot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOTliteralANDvs.ttl
+++ b/schemas/1NOTliteralANDvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOTliteralORvs.ttl
+++ b/schemas/1NOTliteralORvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOTvs.ttl
+++ b/schemas/1NOTvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOTvsANDvs.ttl
+++ b/schemas/1NOTvsANDvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1NOTvsORvs.ttl
+++ b/schemas/1NOTvsORvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1_NOTliteral_ANDvs.ttl
+++ b/schemas/1_NOTliteral_ANDvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1_NOTliteral_ORvs.ttl
+++ b/schemas/1_NOTliteral_ORvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1_NOTvs_ANDvs.ttl
+++ b/schemas/1_NOTvs_ANDvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1_NOTvs_ORvs.ttl
+++ b/schemas/1_NOTvs_ORvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [

--- a/schemas/1bnode.ttl
+++ b/schemas/1bnode.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1bnodeLength.ttl
+++ b/schemas/1bnodeLength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1bnodeMaxlength.ttl
+++ b/schemas/1bnodeMaxlength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1bnodeMinlength.ttl
+++ b/schemas/1bnodeMinlength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1bnodePattern.ttl
+++ b/schemas/1bnodePattern.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1bnodeRef1.ttl
+++ b/schemas/1bnodeRef1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1bnodeRefORRefMinlength.ttl
+++ b/schemas/1bnodeRefORRefMinlength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ;

--- a/schemas/1card2.ttl
+++ b/schemas/1card2.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1card25.ttl
+++ b/schemas/1card25.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1card2Star.ttl
+++ b/schemas/1card2Star.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1card2blank.ttl
+++ b/schemas/1card2blank.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1cardOpt.ttl
+++ b/schemas/1cardOpt.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1cardPlus.ttl
+++ b/schemas/1cardPlus.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1cardStar.ttl
+++ b/schemas/1cardStar.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1datatype.ttl
+++ b/schemas/1datatype.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1datatypeLength.ttl
+++ b/schemas/1datatypeLength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1datatypeRef1.ttl
+++ b/schemas/1datatypeRef1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1datatypelangString.ttl
+++ b/schemas/1datatypelangString.ttl
@@ -4,7 +4,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMaxexclusiveDECIMAL.ttl
+++ b/schemas/1decimalMaxexclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMaxexclusiveDOUBLE.ttl
+++ b/schemas/1decimalMaxexclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMaxexclusiveINTEGER.ttl
+++ b/schemas/1decimalMaxexclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMaxexclusivexsd-byte.ttl
+++ b/schemas/1decimalMaxexclusivexsd-byte.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMaxinclusiveDECIMAL.ttl
+++ b/schemas/1decimalMaxinclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMaxinclusiveDOUBLE.ttl
+++ b/schemas/1decimalMaxinclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMaxinclusiveINTEGER.ttl
+++ b/schemas/1decimalMaxinclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMinexclusiveDECIMAL.ttl
+++ b/schemas/1decimalMinexclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMinexclusiveDOUBLE.ttl
+++ b/schemas/1decimalMinexclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMinexclusiveINTEGER.ttl
+++ b/schemas/1decimalMinexclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMininclusiveDECIMAL.ttl
+++ b/schemas/1decimalMininclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMininclusiveDECIMALLeadTrail.ttl
+++ b/schemas/1decimalMininclusiveDECIMALLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMininclusiveDECIMALintLeadTrail.ttl
+++ b/schemas/1decimalMininclusiveDECIMALintLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMininclusiveDOUBLE.ttl
+++ b/schemas/1decimalMininclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMininclusiveDOUBLELeadTrail.ttl
+++ b/schemas/1decimalMininclusiveDOUBLELeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMininclusiveDOUBLEintLeadTrail.ttl
+++ b/schemas/1decimalMininclusiveDOUBLEintLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMininclusiveINTEGER.ttl
+++ b/schemas/1decimalMininclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1decimalMininclusiveINTEGERLead.ttl
+++ b/schemas/1decimalMininclusiveINTEGERLead.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dot-base.ttl
+++ b/schemas/1dot-base.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dot.ttl
+++ b/schemas/1dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dot3Extends.ttl
+++ b/schemas/1dot3Extends.ttl
@@ -3,10 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2>,
-        <http://a.example/S3>,
-        <http://a.example/S4> .
+    sx:shapes (<http://a.example/S1> <http://a.example/S2> <http://a.example/S3> <http://a.example/S4>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/1dotAND1dotAND1dot.ttl
+++ b/schemas/1dotAND1dotAND1dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
   sx:shapeExprs (

--- a/schemas/1dotANDopen1dotAND1dotclose.ttl
+++ b/schemas/1dotANDopen1dotAND1dotclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
   sx:shapeExprs (

--- a/schemas/1dotAbstract.ttl
+++ b/schemas/1dotAbstract.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeDecl ; sx:abstract true ; sx:shapeExpr [
     a sx:Shape ;

--- a/schemas/1dotAbstractShapeCode1.ttl
+++ b/schemas/1dotAbstractShapeCode1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeDecl ; sx:abstract true ; sx:shapeExpr [
    a sx:Shape ;

--- a/schemas/1dotAnnot3.ttl
+++ b/schemas/1dotAnnot3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ;

--- a/schemas/1dotAnnotAIRIREF.ttl
+++ b/schemas/1dotAnnotAIRIREF.ttl
@@ -4,7 +4,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotAnnotIRIREF.ttl
+++ b/schemas/1dotAnnotIRIREF.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotAnnotSTRING_LITERAL1.ttl
+++ b/schemas/1dotAnnotSTRING_LITERAL1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotClosed.ttl
+++ b/schemas/1dotClosed.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:closed true ;

--- a/schemas/1dotCode1.ttl
+++ b/schemas/1dotCode1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotCode3.ttl
+++ b/schemas/1dotCode3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotCode3fail.ttl
+++ b/schemas/1dotCode3fail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotCodeWithEscapes1.ttl
+++ b/schemas/1dotCodeWithEscapes1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotExtends1.ttl
+++ b/schemas/1dotExtends1.ttl
@@ -3,8 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1> <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/1dotExtra1.ttl
+++ b/schemas/1dotExtra1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotIMPORT1dot.ttl
+++ b/schemas/1dotIMPORT1dot.ttl
@@ -4,7 +4,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
     sx:imports (<1dot>) ;
-    sx:shapes <http://a.example/S2> .
+    sx:shapes (<http://a.example/S2>) .
 
 <http://a.example/S2> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotInline1.ttl
+++ b/schemas/1dotInline1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotLNdefault.ttl
+++ b/schemas/1dotLNdefault.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotLNex-HYPHEN_MINUS.ttl
+++ b/schemas/1dotLNex-HYPHEN_MINUS.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotLNex.ttl
+++ b/schemas/1dotLNex.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotLNexMultiComment.ttl
+++ b/schemas/1dotLNexMultiComment.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotLNexSingleComment.ttl
+++ b/schemas/1dotLNexSingleComment.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotNS2.ttl
+++ b/schemas/1dotNS2.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotNS2MultiComment.ttl
+++ b/schemas/1dotNS2MultiComment.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotNS2SingleComment.ttl
+++ b/schemas/1dotNS2SingleComment.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotNSdefault.ttl
+++ b/schemas/1dotNSdefault.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotNoCode1.ttl
+++ b/schemas/1dotNoCode1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotNoCode3.ttl
+++ b/schemas/1dotNoCode3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotOne1dot.ttl
+++ b/schemas/1dotOne1dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/1dotOne2dot.ttl
+++ b/schemas/1dotOne2dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/1dotPlusAnnotIRIREF.ttl
+++ b/schemas/1dotPlusAnnotIRIREF.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotRef1.ttl
+++ b/schemas/1dotRef1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotRefAND3.ttl
+++ b/schemas/1dotRefAND3.ttl
@@ -3,10 +3,10 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2>,
-        <http://a.example/S3>,
-        <http://a.example/S4> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>
+        <http://a.example/S3>
+        <http://a.example/S4>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotRefLNex1.ttl
+++ b/schemas/1dotRefLNex1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotRefNS1.ttl
+++ b/schemas/1dotRefNS1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotRefOR3.ttl
+++ b/schemas/1dotRefOR3.ttl
@@ -3,10 +3,10 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2>,
-        <http://a.example/S3>,
-        <http://a.example/S4> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>
+        <http://a.example/S3>
+        <http://a.example/S4>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotRefSpaceLNex1.ttl
+++ b/schemas/1dotRefSpaceLNex1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotRefSpaceNS1.ttl
+++ b/schemas/1dotRefSpaceNS1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotSemi.ttl
+++ b/schemas/1dotSemi.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotSemiOne1dotSemi.ttl
+++ b/schemas/1dotSemiOne1dotSemi.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/1dotSemiOne2dotSemis.ttl
+++ b/schemas/1dotSemiOne2dotSemis.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/1dotShapeAND1dot3X.ttl
+++ b/schemas/1dotShapeAND1dot3X.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:Shape ;

--- a/schemas/1dotShapeAnnotAIRIREF.ttl
+++ b/schemas/1dotShapeAnnotAIRIREF.ttl
@@ -4,7 +4,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/1dotShapeAnnotIRIREF.ttl
+++ b/schemas/1dotShapeAnnotIRIREF.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/1dotShapeAnnotSTRING_LITERAL1.ttl
+++ b/schemas/1dotShapeAnnotSTRING_LITERAL1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/1dotShapeCode1.ttl
+++ b/schemas/1dotShapeCode1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotShapeNoCode1.ttl
+++ b/schemas/1dotShapeNoCode1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1dotShapePlusAnnotIRIREF.ttl
+++ b/schemas/1dotShapePlusAnnotIRIREF.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/1doubleMaxexclusiveDECIMAL.ttl
+++ b/schemas/1doubleMaxexclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxexclusiveDECIMALLeadTrail.ttl
+++ b/schemas/1doubleMaxexclusiveDECIMALLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxexclusiveDECIMALint.ttl
+++ b/schemas/1doubleMaxexclusiveDECIMALint.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxexclusiveDECIMALintLeadTrail.ttl
+++ b/schemas/1doubleMaxexclusiveDECIMALintLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxexclusiveDOUBLE.ttl
+++ b/schemas/1doubleMaxexclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxexclusiveDOUBLELeadTrail.ttl
+++ b/schemas/1doubleMaxexclusiveDOUBLELeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxexclusiveDOUBLEint.ttl
+++ b/schemas/1doubleMaxexclusiveDOUBLEint.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxexclusiveDOUBLEintLeadTrail.ttl
+++ b/schemas/1doubleMaxexclusiveDOUBLEintLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxexclusiveINTEGER.ttl
+++ b/schemas/1doubleMaxexclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxexclusiveINTEGERLead.ttl
+++ b/schemas/1doubleMaxexclusiveINTEGERLead.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxinclusiveDECIMAL.ttl
+++ b/schemas/1doubleMaxinclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxinclusiveDOUBLE.ttl
+++ b/schemas/1doubleMaxinclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMaxinclusiveINTEGER.ttl
+++ b/schemas/1doubleMaxinclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMinexclusiveDECIMAL.ttl
+++ b/schemas/1doubleMinexclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMinexclusiveDOUBLE.ttl
+++ b/schemas/1doubleMinexclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMinexclusiveINTEGER.ttl
+++ b/schemas/1doubleMinexclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMininclusiveDECIMAL.ttl
+++ b/schemas/1doubleMininclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMininclusiveDECIMALLeadTrail.ttl
+++ b/schemas/1doubleMininclusiveDECIMALLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMininclusiveDECIMALintLeadTrail.ttl
+++ b/schemas/1doubleMininclusiveDECIMALintLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMininclusiveDOUBLE.ttl
+++ b/schemas/1doubleMininclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMininclusiveDOUBLELeadTrail.ttl
+++ b/schemas/1doubleMininclusiveDOUBLELeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMininclusiveDOUBLEintLeadTrail.ttl
+++ b/schemas/1doubleMininclusiveDOUBLEintLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1doubleMininclusiveINTEGERLead.ttl
+++ b/schemas/1doubleMininclusiveINTEGERLead.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMaxexclusiveDECIMAL.ttl
+++ b/schemas/1floatMaxexclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMaxexclusiveDOUBLE.ttl
+++ b/schemas/1floatMaxexclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMaxexclusiveINTEGER.ttl
+++ b/schemas/1floatMaxexclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMaxinclusiveDECIMAL.ttl
+++ b/schemas/1floatMaxinclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMaxinclusiveDOUBLE.ttl
+++ b/schemas/1floatMaxinclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMaxinclusiveINTEGER.ttl
+++ b/schemas/1floatMaxinclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMinexclusiveDECIMAL.ttl
+++ b/schemas/1floatMinexclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMinexclusiveDOUBLE.ttl
+++ b/schemas/1floatMinexclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMinexclusiveINTEGER.ttl
+++ b/schemas/1floatMinexclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMininclusiveDECIMAL.ttl
+++ b/schemas/1floatMininclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMininclusiveDECIMALLeadTrail.ttl
+++ b/schemas/1floatMininclusiveDECIMALLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMininclusiveDECIMALintLeadTrail.ttl
+++ b/schemas/1floatMininclusiveDECIMALintLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMininclusiveDOUBLE.ttl
+++ b/schemas/1floatMininclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMininclusiveDOUBLELeadTrail.ttl
+++ b/schemas/1floatMininclusiveDOUBLELeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMininclusiveDOUBLEintLeadTrail.ttl
+++ b/schemas/1floatMininclusiveDOUBLEintLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMininclusiveINTEGER.ttl
+++ b/schemas/1floatMininclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1floatMininclusiveINTEGERLead.ttl
+++ b/schemas/1floatMininclusiveINTEGERLead.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1focusBNODELength_dot.ttl
+++ b/schemas/1focusBNODELength_dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
   sx:shapeExprs (

--- a/schemas/1focusBNODE_dot.ttl
+++ b/schemas/1focusBNODE_dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/1focusIRILength_dot.ttl
+++ b/schemas/1focusIRILength_dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/1focusIRI_dot.ttl
+++ b/schemas/1focusIRI_dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/1focusLength-dot.ttl
+++ b/schemas/1focusLength-dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/1focusMaxLength-dot.ttl
+++ b/schemas/1focusMaxLength-dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/1focusMinLength-dot.ttl
+++ b/schemas/1focusMinLength-dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/1focusPattern-dot.ttl
+++ b/schemas/1focusPattern-dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/1focusPatternB-dot.ttl
+++ b/schemas/1focusPatternB-dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/1focusnonLiteral-dot.ttl
+++ b/schemas/1focusnonLiteral-dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/1focusnonLiteralLength-dot.ttl
+++ b/schemas/1focusnonLiteralLength-dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/1focusnonLiteralLength-nonLiteralLength.ttl
+++ b/schemas/1focusnonLiteralLength-nonLiteralLength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/1integerMaxexclusiveDECIMALint.ttl
+++ b/schemas/1integerMaxexclusiveDECIMALint.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMaxexclusiveDOUBLEint.ttl
+++ b/schemas/1integerMaxexclusiveDOUBLEint.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMaxexclusiveINTEGER.ttl
+++ b/schemas/1integerMaxexclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMaxinclusiveDECIMALint.ttl
+++ b/schemas/1integerMaxinclusiveDECIMALint.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMaxinclusiveDOUBLEint.ttl
+++ b/schemas/1integerMaxinclusiveDOUBLEint.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMaxinclusiveINTEGER.ttl
+++ b/schemas/1integerMaxinclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMinexclusiveDECIMALint.ttl
+++ b/schemas/1integerMinexclusiveDECIMALint.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMinexclusiveDOUBLEint.ttl
+++ b/schemas/1integerMinexclusiveDOUBLEint.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMinexclusiveINTEGER.ttl
+++ b/schemas/1integerMinexclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMininclusiveDECIMAL.ttl
+++ b/schemas/1integerMininclusiveDECIMAL.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMininclusiveDECIMALLeadTrail.ttl
+++ b/schemas/1integerMininclusiveDECIMALLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMininclusiveDECIMALint.ttl
+++ b/schemas/1integerMininclusiveDECIMALint.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMininclusiveDECIMALintLeadTrail.ttl
+++ b/schemas/1integerMininclusiveDECIMALintLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMininclusiveDOUBLE.ttl
+++ b/schemas/1integerMininclusiveDOUBLE.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMininclusiveDOUBLELeadTrail.ttl
+++ b/schemas/1integerMininclusiveDOUBLELeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMininclusiveDOUBLEint.ttl
+++ b/schemas/1integerMininclusiveDOUBLEint.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMininclusiveDOUBLEintLeadTrail.ttl
+++ b/schemas/1integerMininclusiveDOUBLEintLeadTrail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMininclusiveINTEGER.ttl
+++ b/schemas/1integerMininclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1integerMininclusiveINTEGERLead.ttl
+++ b/schemas/1integerMininclusiveINTEGERLead.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1inversedot.ttl
+++ b/schemas/1inversedot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1inversedotAnnot3.ttl
+++ b/schemas/1inversedotAnnot3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1inversedotCode1.ttl
+++ b/schemas/1inversedotCode1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1iri.ttl
+++ b/schemas/1iri.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1iriLength.ttl
+++ b/schemas/1iriLength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1iriMaxlength.ttl
+++ b/schemas/1iriMaxlength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1iriMinlength.ttl
+++ b/schemas/1iriMinlength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1iriPattern.ttl
+++ b/schemas/1iriPattern.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1iriPatternbc.ttl
+++ b/schemas/1iriPatternbc.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1iriRef1.ttl
+++ b/schemas/1iriRef1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1iriRefLength1.ttl
+++ b/schemas/1iriRefLength1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1list0PlusDot.ttl
+++ b/schemas/1list0PlusDot.ttl
@@ -29,6 +29,6 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
   ) .
 
 [] a sx:Schema ;
-  sx:shapes
-    <http://a.example/S1> ,
-    <http://a.example/List0PlusDot> .
+  sx:shapes (
+    <http://a.example/S1> 
+    <http://a.example/List0PlusDot>) .

--- a/schemas/1list0PlusIri.ttl
+++ b/schemas/1list0PlusIri.ttl
@@ -32,6 +32,6 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
   ) .
 
 [] a sx:Schema ;
-  sx:shapes
-    <http://a.example/S1> ,
-    <http://a.example/List0PlusIri> .
+  sx:shapes (
+    <http://a.example/S1> 
+    <http://a.example/List0PlusIri>) .

--- a/schemas/1list1PlusIri.ttl
+++ b/schemas/1list1PlusIri.ttl
@@ -33,6 +33,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
   ] .
 
 [] a sx:Schema ;
-  sx:shapes
-    <http://a.example/S1> ,
-    <http://a.example/List1PlusIri> .
+  sx:shapes (
+    <http://a.example/S1> 
+    <http://a.example/List1PlusIri>
+  ) .

--- a/schemas/1literal.ttl
+++ b/schemas/1literal.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalCarrotPatternDollar.ttl
+++ b/schemas/1literalCarrotPatternDollar.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalFractiondigits4.ttl
+++ b/schemas/1literalFractiondigits4.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/1literalFractiondigits5.ttl
+++ b/schemas/1literalFractiondigits5.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/1literalLength.ttl
+++ b/schemas/1literalLength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalLength19.ttl
+++ b/schemas/1literalLength19.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalMaxexclusiveINTEGER.ttl
+++ b/schemas/1literalMaxexclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalMaxinclusiveINTEGER.ttl
+++ b/schemas/1literalMaxinclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalMaxlength.ttl
+++ b/schemas/1literalMaxlength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalMinexclusiveINTEGER.ttl
+++ b/schemas/1literalMinexclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalMininclusiveINTEGER.ttl
+++ b/schemas/1literalMininclusiveINTEGER.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalMinlength.ttl
+++ b/schemas/1literalMinlength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPattern.ttl
+++ b/schemas/1literalPattern.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPattern19.ttl
+++ b/schemas/1literalPattern19.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPatternDollar.ttl
+++ b/schemas/1literalPatternDollar.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPatternEnd.ttl
+++ b/schemas/1literalPatternEnd.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPattern_with_REGEXP_escapes.ttl
+++ b/schemas/1literalPattern_with_REGEXP_escapes.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPattern_with_REGEXP_escapes_bare.ttl
+++ b/schemas/1literalPattern_with_REGEXP_escapes_bare.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPattern_with_REGEXP_escapes_escaped.ttl
+++ b/schemas/1literalPattern_with_REGEXP_escapes_escaped.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPattern_with_UTF8_boundaries.ttl
+++ b/schemas/1literalPattern_with_UTF8_boundaries.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPattern_with_all_controls.ttl
+++ b/schemas/1literalPattern_with_all_controls.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPattern_with_all_meta.ttl
+++ b/schemas/1literalPattern_with_all_meta.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPattern_with_all_punctuation.ttl
+++ b/schemas/1literalPattern_with_all_punctuation.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPattern_with_ascii_boundaries.ttl
+++ b/schemas/1literalPattern_with_ascii_boundaries.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPatternabEnd.ttl
+++ b/schemas/1literalPatternabEnd.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPatterni.ttl
+++ b/schemas/1literalPatterni.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalPlus.ttl
+++ b/schemas/1literalPlus.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalStartPattern.ttl
+++ b/schemas/1literalStartPattern.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalStartPatternEnd.ttl
+++ b/schemas/1literalStartPatternEnd.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalTotaldigits2.ttl
+++ b/schemas/1literalTotaldigits2.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalTotaldigits5.ttl
+++ b/schemas/1literalTotaldigits5.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1literalTotaldigits6.ttl
+++ b/schemas/1literalTotaldigits6.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1nonliteral.ttl
+++ b/schemas/1nonliteral.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1nonliteralLength.ttl
+++ b/schemas/1nonliteralLength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1nonliteralMaxlength.ttl
+++ b/schemas/1nonliteralMaxlength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1nonliteralMinlength.ttl
+++ b/schemas/1nonliteralMinlength.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1nonliteralPattern.ttl
+++ b/schemas/1nonliteralPattern.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1refbnode1.ttl
+++ b/schemas/1refbnode1.ttl
@@ -3,9 +3,9 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes
-        <http://a.example/S1>,
-        _:S2 .
+    sx:shapes (
+        <http://a.example/S1>
+        _:S2) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1refbnode_with_leading_digit1.ttl
+++ b/schemas/1refbnode_with_leading_digit1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes
-        <http://a.example/S1>, _:0 .
+    sx:shapes (
+        <http://a.example/S1> _:0) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1refbnode_with_leading_underscore1.ttl
+++ b/schemas/1refbnode_with_leading_underscore1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes 
-        <http://a.example/S1>, _:_ .
+    sx:shapes (
+        <http://a.example/S1> _:_) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1refbnode_with_spanning_PN_CHARS1.ttl
+++ b/schemas/1refbnode_with_spanning_PN_CHARS1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes _:a·̀ͯ‿.⁀,
-        <http://a.example/S1> .
+    sx:shapes (_:a·̀ͯ‿.⁀
+        <http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1refbnode_with_spanning_PN_CHARS_BASE1.ttl
+++ b/schemas/1refbnode_with_spanning_PN_CHARS_BASE1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes _:AZazÀÖØöø˿ͰͽͿ῿‌‍⁰↏Ⰰ⿯、퟿豈﷏ﷰ�𐀀󯿽,
-        <http://a.example/S1> .
+    sx:shapes (_:AZazÀÖØöø˿ͰͽͿ῿‌‍⁰↏Ⰰ⿯、퟿豈﷏ﷰ�𐀀󯿽
+        <http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1DECIMAL.ttl
+++ b/schemas/1val1DECIMAL.ttl
@@ -4,7 +4,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1DOUBLE.ttl
+++ b/schemas/1val1DOUBLE.ttl
@@ -4,7 +4,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1DOUBLElowercase.ttl
+++ b/schemas/1val1DOUBLElowercase.ttl
@@ -4,7 +4,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1INTEGER.ttl
+++ b/schemas/1val1INTEGER.ttl
@@ -4,7 +4,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1IRIREF.ttl
+++ b/schemas/1val1IRIREF.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1IRIREFClosedExtra1.ttl
+++ b/schemas/1val1IRIREFClosedExtra1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ; sx:closed true ;
   sx:extra <http://a.example/p1> ;

--- a/schemas/1val1IRIREFDatatype.ttl
+++ b/schemas/1val1IRIREFDatatype.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1IRIREFExtra1.ttl
+++ b/schemas/1val1IRIREFExtra1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:extra <http://a.example/p1> ;

--- a/schemas/1val1IRIREFExtra1Closed.ttl
+++ b/schemas/1val1IRIREFExtra1Closed.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ; sx:closed true ;
   sx:extra <http://a.example/p1> ;

--- a/schemas/1val1IRIREFExtra1One.ttl
+++ b/schemas/1val1IRIREFExtra1One.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/1val1IRIREFExtra1p2.ttl
+++ b/schemas/1val1IRIREFExtra1p2.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1LANGTAG.ttl
+++ b/schemas/1val1LANGTAG.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1LNDatatype.ttl
+++ b/schemas/1val1LNDatatype.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL1.ttl
+++ b/schemas/1val1STRING_LITERAL1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL1_with_ECHAR_escapes.ttl
+++ b/schemas/1val1STRING_LITERAL1_with_ECHAR_escapes.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL1_with_UTF8_boundaries.ttl
+++ b/schemas/1val1STRING_LITERAL1_with_UTF8_boundaries.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL1_with_all_controls.ttl
+++ b/schemas/1val1STRING_LITERAL1_with_all_controls.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL1_with_all_punctuation.ttl
+++ b/schemas/1val1STRING_LITERAL1_with_all_punctuation.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL1_with_ascii_boundaries.ttl
+++ b/schemas/1val1STRING_LITERAL1_with_ascii_boundaries.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL2.ttl
+++ b/schemas/1val1STRING_LITERAL2.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL2_with_LANGTAG.ttl
+++ b/schemas/1val1STRING_LITERAL2_with_LANGTAG.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL2_with_subtag.ttl
+++ b/schemas/1val1STRING_LITERAL2_with_subtag.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL_LONG1.ttl
+++ b/schemas/1val1STRING_LITERAL_LONG1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL_LONG2.ttl
+++ b/schemas/1val1STRING_LITERAL_LONG2.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL_LONG2_with_LANGTAG.ttl
+++ b/schemas/1val1STRING_LITERAL_LONG2_with_LANGTAG.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1STRING_LITERAL_LONG2_with_subtag.ttl
+++ b/schemas/1val1STRING_LITERAL_LONG2_with_subtag.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1dotMinusiri3.ttl
+++ b/schemas/1val1dotMinusiri3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1dotMinusiriStem3.ttl
+++ b/schemas/1val1dotMinusiriStem3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1dotMinuslanguage3.ttl
+++ b/schemas/1val1dotMinuslanguage3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1dotMinuslanguageStem3.ttl
+++ b/schemas/1val1dotMinuslanguageStem3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1dotMinusliteral3.ttl
+++ b/schemas/1val1dotMinusliteral3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1dotMinusliteralStem3.ttl
+++ b/schemas/1val1dotMinusliteralStem3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1emptylanguageStem.ttl
+++ b/schemas/1val1emptylanguageStem.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1emptylanguageStemMinuslanguage3.ttl
+++ b/schemas/1val1emptylanguageStemMinuslanguage3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1emptylanguageStemMinuslanguageStem3.ttl
+++ b/schemas/1val1emptylanguageStemMinuslanguageStem3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1false.ttl
+++ b/schemas/1val1false.ttl
@@ -4,7 +4,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1iri.ttl
+++ b/schemas/1val1iri.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1iriStem.ttl
+++ b/schemas/1val1iriStem.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1iriStemMinusiri3.ttl
+++ b/schemas/1val1iriStemMinusiri3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1iriStemMinusiriStem3.ttl
+++ b/schemas/1val1iriStemMinusiriStem3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1language.ttl
+++ b/schemas/1val1language.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1languageStem.ttl
+++ b/schemas/1val1languageStem.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1languageStemMinuslanguage3.ttl
+++ b/schemas/1val1languageStemMinuslanguage3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1languageStemMinuslanguageStem3.ttl
+++ b/schemas/1val1languageStemMinuslanguageStem3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1literal.ttl
+++ b/schemas/1val1literal.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1literalAtlanguageStem.ttl
+++ b/schemas/1val1literalAtlanguageStem.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1literalAtlanguageStemMinusliteralAtlanguage3.ttl
+++ b/schemas/1val1literalAtlanguageStemMinusliteralAtlanguage3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1literalStem.ttl
+++ b/schemas/1val1literalStem.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1literalStemMinusliteral3.ttl
+++ b/schemas/1val1literalStemMinusliteral3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1literalStemMinusliteralStem3.ttl
+++ b/schemas/1val1literalStemMinusliteralStem3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1literaliriStem.ttl
+++ b/schemas/1val1literaliriStem.ttl
@@ -4,7 +4,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1literaliriStemMinusliteraliri3.ttl
+++ b/schemas/1val1literaliriStemMinusliteraliri3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1literallanguageStem.ttl
+++ b/schemas/1val1literallanguageStem.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1literallanguageStemMinusliterallanguage3.ttl
+++ b/schemas/1val1literallanguageStemMinusliterallanguage3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1refvsMinusiri3.ttl
+++ b/schemas/1val1refvsMinusiri3.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/vs1> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/vs1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1true.ttl
+++ b/schemas/1val1true.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1vExpr1AND1AND1Ref3.ttl
+++ b/schemas/1val1vExpr1AND1AND1Ref3.ttl
@@ -3,10 +3,10 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/vc1>,
-        <http://a.example/vc2>,
-        <http://a.example/vc3> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/vc1>
+        <http://a.example/vc2>
+        <http://a.example/vc3>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1vExpr1AND1OR1Ref3.ttl
+++ b/schemas/1val1vExpr1AND1OR1Ref3.ttl
@@ -3,10 +3,10 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/vc1>,
-        <http://a.example/vc2>,
-        <http://a.example/vc3> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/vc1>
+        <http://a.example/vc2>
+        <http://a.example/vc3>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1vExpr1OR1AND1Ref3.ttl
+++ b/schemas/1val1vExpr1OR1AND1Ref3.ttl
@@ -3,10 +3,10 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/vc1>,
-        <http://a.example/vc2>,
-        <http://a.example/vc3> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/vc1>
+        <http://a.example/vc2>
+        <http://a.example/vc3>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1vExpr1OR1OR1Ref3.ttl
+++ b/schemas/1val1vExpr1OR1OR1Ref3.ttl
@@ -3,10 +3,10 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/vc1>,
-        <http://a.example/vc2>,
-        <http://a.example/vc3> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/vc1>
+        <http://a.example/vc2>
+        <http://a.example/vc3>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1vExprAND3.ttl
+++ b/schemas/1val1vExprAND3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1vExprOR3.ttl
+++ b/schemas/1val1vExprOR3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1vExprRefAND3.ttl
+++ b/schemas/1val1vExprRefAND3.ttl
@@ -3,11 +3,11 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/vc1>,
-        <http://a.example/vc2>,
-        <http://a.example/vc3>,
-        <http://a.example/vc4> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/vc1>
+        <http://a.example/vc2>
+        <http://a.example/vc3>
+        <http://a.example/vc4>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1vExprRefIRIREF1.ttl
+++ b/schemas/1val1vExprRefIRIREF1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/vc1> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/vc1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1vExprRefOR3.ttl
+++ b/schemas/1val1vExprRefOR3.ttl
@@ -3,11 +3,11 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/vc1>,
-        <http://a.example/vc2>,
-        <http://a.example/vc3>,
-        <http://a.example/vc4> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/vc1>
+        <http://a.example/vc2>
+        <http://a.example/vc3>
+        <http://a.example/vc4>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1vExprRefbnode1.ttl
+++ b/schemas/1val1vExprRefbnode1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes
-        <http://a.example/S1>, _:vc1 .
+    sx:shapes (
+        <http://a.example/S1> _:vc1) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val1vShapeANDRef3.ttl
+++ b/schemas/1val1vShapeANDRef3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:Shape ;

--- a/schemas/1val2IRIREFExtra1.ttl
+++ b/schemas/1val2IRIREFExtra1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val2IRIREFPlusExtra1.ttl
+++ b/schemas/1val2IRIREFPlusExtra1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1val2STRING_LITERAL1.ttl
+++ b/schemas/1val2STRING_LITERAL1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1valExprRef-IV1.ttl
+++ b/schemas/1valExprRef-IV1.ttl
@@ -4,7 +4,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
     sx:imports (<1valExprRef-vc1>) ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1valExprRef-vc1.ttl
+++ b/schemas/1valExprRef-vc1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/vc1> .
+    sx:shapes (<http://a.example/vc1>) .
 
 <http://a.example/vc1> a sx:NodeConstraint ;
     sx:minlength 5 ;

--- a/schemas/1valExprRefbnode-IV1.ttl
+++ b/schemas/1valExprRefbnode-IV1.ttl
@@ -4,8 +4,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
     sx:imports (<1valExprRefbnode-vc1>) ;
-    sx:shapes
-        <http://a.example/S1> .
+    sx:shapes (
+        <http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/1valExprRefbnode-vc1.ttl
+++ b/schemas/1valExprRefbnode-vc1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes
-        _:vc1 .
+    sx:shapes (
+        _:vc1) .
 
 _:vc1 a sx:NodeConstraint ;
     sx:minlength 5 ;

--- a/schemas/2EachInclude1-IS2.ttl
+++ b/schemas/2EachInclude1-IS2.ttl
@@ -4,7 +4,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
     sx:imports (<2EachInclude1-S2>) ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/2EachInclude1-S2.ttl
+++ b/schemas/2EachInclude1-S2.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S2> .
+    sx:shapes (<http://a.example/S2>) .
 
 <http://a.example/S2> a sx:Shape ;
   sx:expression <http://a.example/S2e> .

--- a/schemas/2EachInclude1-after.ttl
+++ b/schemas/2EachInclude1-after.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/2EachInclude1.ttl
+++ b/schemas/2EachInclude1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/2Eachdot.ttl
+++ b/schemas/2Eachdot.ttl
@@ -2,7 +2,7 @@ PREFIX ex: <http://a.example>
 PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-[] a sx:Schema ; sx:shapes <http://a.example/S> .
+[] a sx:Schema ; sx:shapes (<http://a.example/S>) .
 
 <http://a.example/S> a sx:Shape ;
   sx:expression

--- a/schemas/2OneInclude1-after.ttl
+++ b/schemas/2OneInclude1-after.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/2OneInclude1.ttl
+++ b/schemas/2OneInclude1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>,
-        <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1>
+        <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/2RefS1-IS2.ttl
+++ b/schemas/2RefS1-IS2.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <2RefS2> ) ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ;
         sx:valueExpr <http://a.example/S2> ] .

--- a/schemas/2RefS1-Icirc.ttl
+++ b/schemas/2RefS1-Icirc.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <2RefS2-Icirc> ) ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ;
         sx:valueExpr <http://a.example/S2> ] .

--- a/schemas/2RefS1.ttl
+++ b/schemas/2RefS1.ttl
@@ -1,7 +1,7 @@
 PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ;
         sx:valueExpr <http://a.example/S2> ] .

--- a/schemas/2RefS2-IS1.ttl
+++ b/schemas/2RefS2-IS1.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <2RefS1> ) ;
-  sx:shapes <http://a.example/S2> .
+  sx:shapes (<http://a.example/S2>) .
     <http://a.example/S2> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p2> ] .
 

--- a/schemas/2RefS2-Icirc.ttl
+++ b/schemas/2RefS2-Icirc.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <2RefS1-Icirc> ) ;
-  sx:shapes <http://a.example/S2> .
+  sx:shapes (<http://a.example/S2>) .
     <http://a.example/S2> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p2> ] .
 

--- a/schemas/2RefS2.ttl
+++ b/schemas/2RefS2.ttl
@@ -1,7 +1,7 @@
 PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
-  sx:shapes <http://a.example/S2> .
+  sx:shapes (<http://a.example/S2>) .
     <http://a.example/S2> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p2> ] .
 

--- a/schemas/2dot.ttl
+++ b/schemas/2dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/2dotOne1dot.ttl
+++ b/schemas/2dotOne1dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/2dotSemiOne1dotSemi.ttl
+++ b/schemas/2dotSemiOne1dotSemi.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/2dotSemis.ttl
+++ b/schemas/2dotSemis.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/3Eachdot.ttl
+++ b/schemas/3Eachdot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/3Eachdot3Extra.ttl
+++ b/schemas/3Eachdot3Extra.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/3EachdotExtra3.ttl
+++ b/schemas/3EachdotExtra3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/3EachdotExtra3NLex.ttl
+++ b/schemas/3EachdotExtra3NLex.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/3circRefPlus1.ttl
+++ b/schemas/3circRefPlus1.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-  sx:shapes <http://a.example/S1>, <http://a.example/S2>,
-            <http://a.example/S3>, <http://a.example/S4> .
+  sx:shapes (<http://a.example/S1> <http://a.example/S2>
+            <http://a.example/S3> <http://a.example/S4>) .
 
 <http://a.example/S4> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ; sx:predicate <http://a.example/p5> ] .

--- a/schemas/3circRefS1-IS2-IS3-IS3.ttl
+++ b/schemas/3circRefS1-IS2-IS3-IS3.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <3circRefS2-IS3> <3circRefS3> ) ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:EachOf ; sx:expressions (
           [ a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ]

--- a/schemas/3circRefS1-IS2-IS3.ttl
+++ b/schemas/3circRefS1-IS2-IS3.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <3circRefS2-IS3> ) ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:EachOf ; sx:expressions (
           [ a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ]

--- a/schemas/3circRefS1-IS23.ttl
+++ b/schemas/3circRefS1-IS23.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <3circRefS23> ) ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:EachOf ; sx:expressions (
           [ a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ]

--- a/schemas/3circRefS1-Icirc.ttl
+++ b/schemas/3circRefS1-Icirc.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <3circRefS2-Icirc> ) ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:EachOf ; sx:expressions (
           [ a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ]

--- a/schemas/3circRefS12.ttl
+++ b/schemas/3circRefS12.ttl
@@ -1,7 +1,7 @@
 PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
-  sx:shapes <http://a.example/S1>, <http://a.example/S2> .
+  sx:shapes (<http://a.example/S1> <http://a.example/S2>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:EachOf ; sx:expressions (
           [ a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ]

--- a/schemas/3circRefS123-Icirc.ttl
+++ b/schemas/3circRefS123-Icirc.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <3circRefS123-Icirc> ) ;
-  sx:shapes <http://a.example/S1>, <http://a.example/S2>, <http://a.example/S3> .
+  sx:shapes (<http://a.example/S1> <http://a.example/S2> <http://a.example/S3>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:EachOf ; sx:expressions (
           [ a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ]

--- a/schemas/3circRefS123.ttl
+++ b/schemas/3circRefS123.ttl
@@ -1,7 +1,7 @@
 PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
-  sx:shapes <http://a.example/S1>, <http://a.example/S2>, <http://a.example/S3> .
+  sx:shapes (<http://a.example/S1> <http://a.example/S2> <http://a.example/S3>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:EachOf ; sx:expressions (
           [ a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ]

--- a/schemas/3circRefS2-IS3.ttl
+++ b/schemas/3circRefS2-IS3.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <3circRefS3> ) ;
-  sx:shapes <http://a.example/S2> .
+  sx:shapes (<http://a.example/S2>) .
     <http://a.example/S2> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p3> ;
         sx:valueExpr <http://a.example/S3> ] .

--- a/schemas/3circRefS2-Icirc.ttl
+++ b/schemas/3circRefS2-Icirc.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <3circRefS3-Icirc> ) ;
-  sx:shapes <http://a.example/S2> .
+  sx:shapes (<http://a.example/S2>) .
     <http://a.example/S2> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p3> ;
         sx:valueExpr <http://a.example/S3> ] .

--- a/schemas/3circRefS23.ttl
+++ b/schemas/3circRefS23.ttl
@@ -1,7 +1,7 @@
 PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
-  sx:shapes <http://a.example/S2>, <http://a.example/S3> .
+  sx:shapes (<http://a.example/S2> <http://a.example/S3>) .
     <http://a.example/S2> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p3> ;
         sx:valueExpr <http://a.example/S3> ] .

--- a/schemas/3circRefS3-IS12.ttl
+++ b/schemas/3circRefS3-IS12.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <3circRefS12> ) ;
-  sx:shapes <http://a.example/S3> .
+  sx:shapes (<http://a.example/S3>) .
     <http://a.example/S3> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p4> ;
         sx:valueExpr <http://a.example/S1> ] .

--- a/schemas/3circRefS3-Icirc.ttl
+++ b/schemas/3circRefS3-Icirc.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:imports ( <3circRefS1-Icirc> ) ;
-  sx:shapes <http://a.example/S3> .
+  sx:shapes (<http://a.example/S3>) .
     <http://a.example/S3> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p4> ;
         sx:valueExpr <http://a.example/S1> ] .

--- a/schemas/3circRefS3.ttl
+++ b/schemas/3circRefS3.ttl
@@ -1,7 +1,7 @@
 PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
-  sx:shapes <http://a.example/S3> .
+  sx:shapes (<http://a.example/S3>) .
     <http://a.example/S3> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p4> ;
         sx:valueExpr <http://a.example/S1> ] .

--- a/schemas/AND3G.ttl
+++ b/schemas/AND3G.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/A>, <http://a.example/B>, <http://a.example/C>, <http://a.example/D> .
+    sx:shapes (<http://a.example/A> <http://a.example/B> <http://a.example/C> <http://a.example/D>) .
 
 <http://a.example/A> a sx:ShapeDecl ;
     sx:abstract true ;

--- a/schemas/ANDAbstract.ttl
+++ b/schemas/ANDAbstract.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/A>, <http://a.example/B> .
+    sx:shapes (<http://a.example/A> <http://a.example/B>) .
 
 <http://a.example/A> a sx:ShapeDecl ;
     sx:abstract true ;

--- a/schemas/Cycle2Extra.ttl
+++ b/schemas/Cycle2Extra.ttl
@@ -1,7 +1,7 @@
 PREFIX shex: <http://www.w3.org/ns/shex#>
 
-[ a shex:Schema ;
-  shex:shapes <http://example.org/S> , <http://example.org/T> ] .
+[] a shex:Schema ;
+  shex:shapes (<http://example.org/S>  <http://example.org/T>) .
 
 <http://example.org/S> a shex:Shape ;
   shex:extra <http://example.org/a> ;

--- a/schemas/Cycle2NoNegation.ttl
+++ b/schemas/Cycle2NoNegation.ttl
@@ -1,7 +1,7 @@
 PREFIX shex: <http://www.w3.org/ns/shex#>
 
-[ a shex:Schema ;
-  shex:shapes <http://example.org/S> ] .
+[] a shex:Schema ;
+  shex:shapes (<http://example.org/S>) .
 <http://example.org/S> a shex:Shape ;
   shex:expression [
     a shex:TripleConstraint ;

--- a/schemas/CycleNoNegation.ttl
+++ b/schemas/CycleNoNegation.ttl
@@ -1,7 +1,7 @@
 PREFIX shex: <http://www.w3.org/ns/shex#>
 
-[ a shex:Schema ;
-  shex:shapes <http://example.org/S> ] .
+[] a shex:Schema ;
+  shex:shapes (<http://example.org/S>) .
 
 <http://example.org/S> a shex:Shape ;
   shex:expression [

--- a/schemas/Extend3G.ttl
+++ b/schemas/Extend3G.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/A>, <http://a.example/B>, <http://a.example/C>, <http://a.example/D>, <http://a.example/E>, <http://a.example/F>, <http://a.example/G> .
+    sx:shapes (<http://a.example/A> <http://a.example/B> <http://a.example/C> <http://a.example/D> <http://a.example/E> <http://a.example/F> <http://a.example/G>) .
 
 <http://a.example/A> a sx:ShapeDecl ;
     sx:abstract true ;

--- a/schemas/ExtendAND3G.ttl
+++ b/schemas/ExtendAND3G.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/A>, <http://a.example/B>, <http://a.example/C>, <http://a.example/D>, <http://a.example/E> .
+    sx:shapes (<http://a.example/A> <http://a.example/B> <http://a.example/C> <http://a.example/D> <http://a.example/E>) .
 
 <http://a.example/A> a sx:ShapeDecl ;
     sx:abstract true ;

--- a/schemas/ExtendANDExtend3GAND3G.ttl
+++ b/schemas/ExtendANDExtend3GAND3G.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/A>, <http://a.example/B>, <http://a.example/C>, <http://a.example/D>, <http://a.example/E>, <http://a.example/F>, <http://a.example/G>, <http://a.example/H>, <http://a.example/I>, <http://a.example/J> .
+    sx:shapes (<http://a.example/A> <http://a.example/B> <http://a.example/C> <http://a.example/D> <http://a.example/E> <http://a.example/F> <http://a.example/G> <http://a.example/H> <http://a.example/I> <http://a.example/J>) .
 
 <http://a.example/A> a sx:ShapeDecl ;
     sx:abstract true ;

--- a/schemas/Extends-sAB.ttl
+++ b/schemas/Extends-sAB.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/A>, <http://a.example/B> .
+    sx:shapes (<http://a.example/A> <http://a.example/B>) .
 
 <http://a.example/A> a sx:ShapeDecl ;
     sx:abstract true ;

--- a/schemas/ExtendsRepeatedP.ttl
+++ b/schemas/ExtendsRepeatedP.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/#A>, <http://a.example/#B>, <http://a.example/#C> .
+    sx:shapes (<http://a.example/#A> <http://a.example/#B> <http://a.example/#C>) .
 
 <http://a.example/#A>a sx:Shape ;
 sx:expression [ a sx:EachOf;

--- a/schemas/FocusIRI2EachBnodeNested2EachIRIRef.ttl
+++ b/schemas/FocusIRI2EachBnodeNested2EachIRIRef.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
   sx:shapeExprs (

--- a/schemas/NOT1NOTvs.ttl
+++ b/schemas/NOT1NOTvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeNot ;
   sx:shapeExpr [

--- a/schemas/NOT1dotOR2dot.ttl
+++ b/schemas/NOT1dotOR2dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeOr ;
     sx:shapeExprs ( [ a sx:ShapeNot ;

--- a/schemas/NOT1dotOR2dotX3.ttl
+++ b/schemas/NOT1dotOR2dotX3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
   sx:shapeExprs (

--- a/schemas/NOT1dotOR2dotX3AND1.ttl
+++ b/schemas/NOT1dotOR2dotX3AND1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:ShapeOr ;

--- a/schemas/NoNegation.ttl
+++ b/schemas/NoNegation.ttl
@@ -1,7 +1,7 @@
 PREFIX shex: <http://www.w3.org/ns/shex#>
 
-[ a shex:Schema ;
-  shex:shapes <http://example.org/S> , <http://example.org/T> , <http://example.org/U> ] .
+[] a shex:Schema ;
+  shex:shapes (<http://example.org/S>  <http://example.org/T>  <http://example.org/U>) .
 
 <http://example.org/S> a shex:ShapeAnd ;
   shex:shapeExprs (

--- a/schemas/NoNegation2.ttl
+++ b/schemas/NoNegation2.ttl
@@ -1,7 +1,7 @@
 PREFIX shex: <http://www.w3.org/ns/shex#>
 
-[ a shex:Schema ;
-  shex:shapes <http://example.org/S> , <http://example.org/T> , <http://example.org/U> ] .
+[] a shex:Schema ;
+  shex:shapes (<http://example.org/S>  <http://example.org/T>  <http://example.org/U>) .
 
 <http://example.org/S> a shex:Shape ;
   shex:expression [

--- a/schemas/OneNegation.ttl
+++ b/schemas/OneNegation.ttl
@@ -1,7 +1,7 @@
 PREFIX shex: <http://www.w3.org/ns/shex#>
 
-[ a shex:Schema ;
-  shex:shapes <http://example.org/S> , <http://example.org/T> , <http://example.org/U> ] .
+[] a shex:Schema ;
+  shex:shapes (<http://example.org/S>  <http://example.org/T>  <http://example.org/U>) .
 
 <http://example.org/S> a shex:ShapeAnd .
 <http://example.org/S> shex:shapeExprs (

--- a/schemas/TwoNegation.ttl
+++ b/schemas/TwoNegation.ttl
@@ -1,7 +1,7 @@
 PREFIX shex: <http://www.w3.org/ns/shex#>
 
-[ a shex:Schema ;
-  shex:shapes <http://example.org/S> , <http://example.org/T> , <http://example.org/U> ] .
+[] a shex:Schema ;
+  shex:shapes (<http://example.org/S>  <http://example.org/T>  <http://example.org/U>) .
 
 <http://example.org/S> a shex:Shape ;
  shex:expression [

--- a/schemas/_all.ttl
+++ b/schemas/_all.ttl
@@ -16,15 +16,15 @@ PREFIX a: <http://all.example/>
     sx:code " START2 ";
     sx:name <http://all.example/act2>
   ]);
-  sx:shapes
-    <http://all.example/IRI>,
-    <http://all.example/S1>,
-    <http://all.example/S2>,
-    <http://all.example/S3>,
-    <http://all.example/S5>,
-    <http://all.example/vs1>,
-    _:a·̀ͯ‿.⁀,
-    _:AZazÀÖØöø˿ͰͽͿ῿‌‍⁰↏Ⰰ⿯、퟿豈﷏ﷰ�𐀀󯿽 .
+  sx:shapes (
+    <http://all.example/IRI>
+    <http://all.example/S1>
+    <http://all.example/S2>
+    <http://all.example/S3>
+    <http://all.example/S5>
+    <http://all.example/vs1>
+    _:a·̀ͯ‿.⁀
+    _:AZazÀÖØöø˿ͰͽͿ῿‌‍⁰↏Ⰰ⿯、퟿豈﷏ﷰ�𐀀󯿽) .
 
 <http://all.example/IRI> a sx:NodeConstraint ; sx:nodeKind sx:iri .
 

--- a/schemas/bnode1dot.ttl
+++ b/schemas/bnode1dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes _:S1 .
+    sx:shapes (_:S1) .
 _:S1 a sx:Shape ;
             sx:expression [ a sx:TripleConstraint ;
                     sx:predicate <http://a.example/p1> ] .

--- a/schemas/datatypes.ttl
+++ b/schemas/datatypes.ttl
@@ -2,26 +2,26 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-  sx:shapes
-    <http://a.example/S-integer> ,
-    <http://a.example/S-decimal> ,
-    <http://a.example/S-float> ,
-    <http://a.example/S-double> ,
-    <http://a.example/S-string> ,
-    <http://a.example/S-boolean> ,
-    <http://a.example/S-dateTime> ,
-    <http://a.example/S-nonPositiveInteger> ,
-    <http://a.example/S-negativeInteger> ,
-    <http://a.example/S-long> ,
-    <http://a.example/S-int> ,
-    <http://a.example/S-short> ,
-    <http://a.example/S-byte> ,
-    <http://a.example/S-nonNegativeInteger> ,
-    <http://a.example/S-unsignedLong> ,
-    <http://a.example/S-unsignedInt> ,
-    <http://a.example/S-unsignedShort> ,
-    <http://a.example/S-unsignedByte> ,
-    <http://a.example/S-positiveInteger> .
+  sx:shapes (
+    <http://a.example/S-integer> 
+    <http://a.example/S-decimal> 
+    <http://a.example/S-float> 
+    <http://a.example/S-double> 
+    <http://a.example/S-string> 
+    <http://a.example/S-boolean> 
+    <http://a.example/S-dateTime> 
+    <http://a.example/S-nonPositiveInteger> 
+    <http://a.example/S-negativeInteger> 
+    <http://a.example/S-long> 
+    <http://a.example/S-int> 
+    <http://a.example/S-short> 
+    <http://a.example/S-byte> 
+    <http://a.example/S-nonNegativeInteger> 
+    <http://a.example/S-unsignedLong> 
+    <http://a.example/S-unsignedInt> 
+    <http://a.example/S-unsignedShort> 
+    <http://a.example/S-unsignedByte> 
+    <http://a.example/S-positiveInteger>) .
 
 <http://a.example/S-integer> a sx:Shape ;
   sx:expression [ a sx:TripleConstraint ;

--- a/schemas/dependent_shape.ttl
+++ b/schemas/dependent_shape.ttl
@@ -17,8 +17,7 @@
      ]
    ] .
 
- [
+[]
      a <http://www.w3.org/ns/shex#Schema>;
-     <http://www.w3.org/ns/shex#shapes> <http://schema.example/TesterShape>,
-       <http://schema.example/IssueShape>
- ] .
+     <http://www.w3.org/ns/shex#shapes> (<http://schema.example/TesterShape>
+       <http://schema.example/IssueShape>) .

--- a/schemas/focusNOTRefOR1dot.ttl
+++ b/schemas/focusNOTRefOR1dot.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>, <http://a.example/S2> .
+    sx:shapes (<http://a.example/S1> <http://a.example/S2>) .
 
 <http://a.example/S1> a sx:ShapeOr ;
     sx:shapeExprs (

--- a/schemas/focusbnode0ORfocusPattern0.ttl
+++ b/schemas/focusbnode0ORfocusPattern0.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeOr ;
   sx:shapeExprs (

--- a/schemas/focusdatatype.ttl
+++ b/schemas/focusdatatype.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:NodeConstraint ;
     sx:datatype <http://a.example/bloodType> .

--- a/schemas/focusvs.ttl
+++ b/schemas/focusvs.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/vs1> .
+    sx:shapes (<http://a.example/vs1>) .
 
 <http://a.example/vs1> a sx:NodeConstraint ;
     sx:values ( <http://a.example/v1> <http://a.example/v2> <http://a.example/v3> ) .

--- a/schemas/focusvsANDIRI.ttl
+++ b/schemas/focusvsANDIRI.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/vs1> .
+    sx:shapes (<http://a.example/vs1>) .
 
 <http://a.example/vs1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/focusvsANDdatatype.ttl
+++ b/schemas/focusvsANDdatatype.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/vs1> .
+    sx:shapes (<http://a.example/vs1>) .
 
 <http://a.example/vs1> a sx:ShapeAnd ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/focusvsORdatatype.ttl
+++ b/schemas/focusvsORdatatype.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/vs1> .
+    sx:shapes (<http://a.example/vs1>) .
 
 <http://a.example/vs1> a sx:ShapeOr ;
     sx:shapeExprs ( [ a sx:NodeConstraint ;

--- a/schemas/kitchenSink.ttl
+++ b/schemas/kitchenSink.ttl
@@ -16,12 +16,12 @@ prefix rdfs: <http://www.w3.org/2000/01/rdf-schem#>
     [ a sx:SemAct ; sx:name ex:foo ; sx:code " initializer for ignored extension " ]
   ) ;
   sx:start <S1> ;
-  sx:shapes
-      <S1> ,
-      UserShape: ,
-      :EmployeeShape ,
-      _:IDshape ,
-      ex:FooID .
+  sx:shapes (
+      <S1> 
+      UserShape: 
+      :EmployeeShape 
+      _:IDshape 
+      ex:FooID) .
 
 <S1> a sx:Shape ;
   sx:expression [ a sx:EachOf ; sx:expressions (

--- a/schemas/node_kind_example.ttl
+++ b/schemas/node_kind_example.ttl
@@ -2,7 +2,7 @@ PREFIX ex: <http://schema.example/>
 PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
-    sx:shapes ex:IssueShape .
+    sx:shapes (ex:IssueShape) .
 
 ex:IssueShape a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/open1dotAND1dotcloseAND1dot.ttl
+++ b/schemas/open1dotAND1dotcloseAND1dot.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:ShapeAnd ;
   sx:shapeExprs (

--- a/schemas/open1dotOne1dotclose.ttl
+++ b/schemas/open1dotOne1dotclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/open1dotOne2dotclose.ttl
+++ b/schemas/open1dotOne2dotclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/open1dotOneopen2dotcloseclose.ttl
+++ b/schemas/open1dotOneopen2dotcloseclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/open1dotSemiOne1dotSemicloseSemi.ttl
+++ b/schemas/open1dotSemiOne1dotSemicloseSemi.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/open1dotSemiOne2dotsemisclose.ttl
+++ b/schemas/open1dotSemiOne2dotsemisclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/open1dotSemiOneopen2dotSemiscloseclose.ttl
+++ b/schemas/open1dotSemiOneopen2dotSemiscloseclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/open1dotopen1dotOne1dotcloseclose.ttl
+++ b/schemas/open1dotopen1dotOne1dotcloseclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/open1dotopen1dotSemiOne1dotSemicloseSemicloseSemi.ttl
+++ b/schemas/open1dotopen1dotSemiOne1dotSemicloseSemicloseSemi.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/open2Eachdotclosecard25c1dot.ttl
+++ b/schemas/open2Eachdotclosecard25c1dot.ttl
@@ -2,7 +2,7 @@ PREFIX ex: <http://a.example>
 PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-[] a sx:Schema ; sx:shapes <http://a.example/S> .
+[] a sx:Schema ; sx:shapes (<http://a.example/S>) .
 
 <http://a.example/S> a sx:Shape ;
   sx:expression

--- a/schemas/open2dotOne1dotclose.ttl
+++ b/schemas/open2dotOne1dotclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/open2dotSemisOne1dotSemiclose.ttl
+++ b/schemas/open2dotSemisOne1dotSemiclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/open2dotclose.ttl
+++ b/schemas/open2dotclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/open2dotsemisclose.ttl
+++ b/schemas/open2dotsemisclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/open3Eachdotclose.ttl
+++ b/schemas/open3Eachdotclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/open3EachdotcloseAnnot3.ttl
+++ b/schemas/open3EachdotcloseAnnot3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/open3EachdotcloseCode1.ttl
+++ b/schemas/open3EachdotcloseCode1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:EachOf ;

--- a/schemas/open3Eachdotclosecard23.ttl
+++ b/schemas/open3Eachdotclosecard23.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/open3Eachdotclosecard23Annot3Code2.ttl
+++ b/schemas/open3Eachdotclosecard23Annot3Code2.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/open3Onedotclosecard2.ttl
+++ b/schemas/open3Onedotclosecard2.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression [ a sx:OneOf ;

--- a/schemas/open3Onedotclosecard23.ttl
+++ b/schemas/open3Onedotclosecard23.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/open4Onedotclosecard23.ttl
+++ b/schemas/open4Onedotclosecard23.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/openopen1dotOne1dotclose1dotclose.ttl
+++ b/schemas/openopen1dotOne1dotclose1dotclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/openopen1dotSemiOne1dotSemiclose1dotSemicloseSemi.ttl
+++ b/schemas/openopen1dotSemiOne1dotSemiclose1dotSemicloseSemi.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:EachOf ;

--- a/schemas/openopen2dotSemiscloseOne1dotSemiclose.ttl
+++ b/schemas/openopen2dotSemiscloseOne1dotSemiclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/openopen2dotcloseOne1dotclose.ttl
+++ b/schemas/openopen2dotcloseOne1dotclose.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> .
+    sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:OneOf ;

--- a/schemas/recursion_example.ttl
+++ b/schemas/recursion_example.ttl
@@ -10,7 +10,6 @@
      <http://www.w3.org/ns/shex#valueExpr> <http://schema.example/IssueShape>
    ] .
 
- [
+[]
      a <http://www.w3.org/ns/shex#Schema>;
-     <http://www.w3.org/ns/shex#shapes> <http://schema.example/IssueShape>
- ] .
+     <http://www.w3.org/ns/shex#shapes> (<http://schema.example/IssueShape>) .

--- a/schemas/shapeExtern.ttl
+++ b/schemas/shapeExtern.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/Sext> .
+    sx:shapes (<http://a.example/Sext>) .
 
 <http://a.example/Sext> a sx:ShapeExternal .
 

--- a/schemas/shapeExternRef.ttl
+++ b/schemas/shapeExternRef.ttl
@@ -3,8 +3,8 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S>,
-        <http://a.example/Sext> .
+    sx:shapes (<http://a.example/S>
+        <http://a.example/Sext>) .
 
 <http://a.example/S> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/start2RefS1-IstartS2.ttl
+++ b/schemas/start2RefS1-IstartS2.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 [] a sx:Schema ;
   sx:imports ( <start2RefS2> ) ;
   sx:start <http://a.example/S1> ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ;
         sx:valueExpr <http://a.example/S2> ] .

--- a/schemas/start2RefS1.ttl
+++ b/schemas/start2RefS1.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:start <http://a.example/S2> ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
     <http://a.example/S1> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ] .
 

--- a/schemas/start2RefS2-IstartS1.ttl
+++ b/schemas/start2RefS2-IstartS1.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 [] a sx:Schema ;
   sx:imports ( <start2RefS1> ) ;
   sx:start <http://a.example/S2> ;
-  sx:shapes <http://a.example/S2> .
+  sx:shapes (<http://a.example/S2>) .
     <http://a.example/S2> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p2> ;
         sx:valueExpr <http://a.example/S1> ] .

--- a/schemas/start2RefS2.ttl
+++ b/schemas/start2RefS2.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:start <http://a.example/S2> ;
-  sx:shapes <http://a.example/S2> .
+  sx:shapes (<http://a.example/S2>) .
     <http://a.example/S2> a sx:Shape ; sx:expression [
         a sx:TripleConstraint ; sx:predicate <http://a.example/p1> ] .
 

--- a/schemas/startCode1.ttl
+++ b/schemas/startCode1.ttl
@@ -3,12 +3,12 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> ;
+    sx:shapes (<http://a.example/S1>) ;
     sx:startActs ([
-      a sx:SemAct;
-      sx:code " print(\"startAct\") ";
+      a sx:SemAct ;
+      sx:code " print(\"startAct\") " ;
       sx:name <http://shex.io/extensions/Test/>
-    ]).
+    ]) .
 
 <http://a.example/S1> a sx:Shape ;
     sx:expression [ a sx:TripleConstraint ;

--- a/schemas/startCode1fail.ttl
+++ b/schemas/startCode1fail.ttl
@@ -3,10 +3,10 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>;
+    sx:shapes (<http://a.example/S1>) ;
     sx:startActs ([
-      a sx:SemAct;
-      sx:code " fail(\"startAct\") ";
+      a sx:SemAct ;
+      sx:code " fail(\"startAct\") " ;
       sx:name <http://shex.io/extensions/Test/>
     ]) .
 

--- a/schemas/startCode1startRef.ttl
+++ b/schemas/startCode1startRef.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> ;
+    sx:shapes (<http://a.example/S1>) ;
     sx:start <http://a.example/S1>;
     sx:startActs ([
       a sx:SemAct;

--- a/schemas/startCode1startReffail.ttl
+++ b/schemas/startCode1startReffail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1> ;
+    sx:shapes (<http://a.example/S1>) ;
     sx:start <http://a.example/S1>;
     sx:startActs ([
       a sx:SemAct;

--- a/schemas/startCode3.ttl
+++ b/schemas/startCode3.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>;
+    sx:shapes (<http://a.example/S1>);
     sx:startActs ([
       a sx:SemAct;
       sx:code " print(\"startAct 1\") ";

--- a/schemas/startCode3fail.ttl
+++ b/schemas/startCode3fail.ttl
@@ -3,7 +3,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>;
+    sx:shapes (<http://a.example/S1>);
     <http://www.w3.org/ns/shex#startActs> ([
       a <http://www.w3.org/ns/shex#SemAct>;
       <http://www.w3.org/ns/shex#code> " print(\"startAct 1\") ";

--- a/schemas/startNoCode1.ttl
+++ b/schemas/startNoCode1.ttl
@@ -3,9 +3,9 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/S1>;
+    sx:shapes (<http://a.example/S1>) ;
     sx:startActs ([
-      a sx:SemAct;
+      a sx:SemAct ;
       sx:name <http://shex.io/extensions/Test/>
     ]) .
 

--- a/schemas/startRefIRIREF.ttl
+++ b/schemas/startRefIRIREF.ttl
@@ -4,7 +4,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
   sx:start <http://a.example/S1> ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/startRefbnode.ttl
+++ b/schemas/startRefbnode.ttl
@@ -4,7 +4,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
     sx:start _:S1 ;
-    sx:shapes _:S1 .
+    sx:shapes (_:S1) .
 
 
 _:S1 a sx:Shape ;

--- a/schemas/startSelfRefIRIREF.ttl
+++ b/schemas/startSelfRefIRIREF.ttl
@@ -4,7 +4,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
   sx:start <http://a.example/S1> ;
-  sx:shapes <http://a.example/S1> .
+  sx:shapes (<http://a.example/S1>) .
 
 <http://a.example/S1> a sx:Shape ;
   sx:expression

--- a/schemas/startSelfRefbnode.ttl
+++ b/schemas/startSelfRefbnode.ttl
@@ -4,7 +4,7 @@ PREFIX sx:  <http://www.w3.org/ns/shex#>
 
 [] a sx:Schema ;
   sx:start _:S1 ;
-  sx:shapes _:S1 .
+  sx:shapes (_:S1) .
 
 _:S1 a sx:Shape ;
   sx:expression

--- a/schemas/vitals-RESTRICTS.ttl
+++ b/schemas/vitals-RESTRICTS.ttl
@@ -2,7 +2,7 @@ PREFIX sx: <http://www.w3.org/ns/shex#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 [] a sx:Schema ;
-    sx:shapes <http://a.example/#Observation>, <http://a.example/#Vital>, <http://a.example/#PostureVital>, <http://a.example/#ReclinedVital>, <http://a.example/#BP>, <http://a.example/#PostureBP>, <http://a.example/#ReclinedBP>, <http://a.example/#Pulse>, <http://a.example/#PosturePulse>, <http://a.example/#ReclinedPulse>, <http://a.example/#Posture>, <http://a.example/#Reclined> .
+    sx:shapes (<http://a.example/#Observation> <http://a.example/#Vital> <http://a.example/#PostureVital> <http://a.example/#ReclinedVital> <http://a.example/#BP> <http://a.example/#PostureBP> <http://a.example/#ReclinedBP> <http://a.example/#Pulse> <http://a.example/#PosturePulse> <http://a.example/#ReclinedPulse> <http://a.example/#Posture> <http://a.example/#Reclined>) .
 
 <http://a.example/#Observation> a sx:Shape ;
 sx:expression [ a sx:EachOf;

--- a/validation/manifest.jsonld
+++ b/validation/manifest.jsonld
@@ -19467,6 +19467,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "<A> { :p{2}; :q[3] } <B> @<A>AND{ :p+; :q+ } <C> EXT @<B> { :p } on { :s :p 1,2,3; :q 3 }",
           "status": "mf:proposed"
         },
         {
@@ -19483,6 +19484,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "<A> { :p{2}; :q[3] } <B> @<A>AND{ :p+; :q+ } <C> EXT @<B> { :p } on { :s :p 1,2,3; :q 99 }",
           "status": "mf:proposed"
         },
         {
@@ -19499,6 +19501,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "ABSTRACT <A> /sA/ AND {:p} <B> @<A> AND /s B/ {:p} on { <sABxxxxxxxxx> <p> 0 }",
           "status": "mf:proposed"
         },
         {
@@ -19515,6 +19518,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "ABSTRACT <A> /sA/ AND {:p} <B> @<A> AND /s B/ {:p} on { <sAxxxxxxxxxx> <p> 0 }",
           "status": "mf:proposed"
         },
         {
@@ -19531,6 +19535,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "ABSTRACT <A> /sA/ AND {:p} <B> @<A> AND /s B/ {:p} on { <sxBxxxxxxxxx> <p> 0 }",
           "status": "mf:proposed"
         },
         {
@@ -19547,6 +19552,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "ABS <A> ABS <B> @<A> <C> <D> @<B> AND @<A> on { <sABCDxxxxxxx> <p> 0 }",
           "status": "mf:proposed"
         },
         {
@@ -19563,6 +19569,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "ABS <A> ABS <B> @<A> <C> <D> @<B> AND @<A> on { <sAxxxxxxxxxx> <p> 0 }",
           "status": "mf:proposed"
         },
         {
@@ -19579,6 +19586,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "ABS <A> ABS <B> @<A> <C> <D> @<B> AND @<A> on { <sxxCxxxxxxxx> <p> 0 }",
           "status": "mf:proposed"
         },
         {
@@ -19596,6 +19604,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "<E> EXTENDS @<D> {:p [2]} on { <sABCDExxxxxx> <p> 0, 2 }",
           "status": "mf:proposed"
         },
         {
@@ -19612,6 +19621,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "<E> EXTENDS @<D> {:p [2]} on { <sABCDExxxxxx> <p> 2 }",
           "status": "mf:proposed"
         },
         {
@@ -19628,6 +19638,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "<E> EXTENDS @<D> {:p [2]} on { <sABCDExxxxxx> <p> 0, 2, 3 }",
           "status": "mf:proposed"
         },
         {
@@ -19644,6 +19655,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "<E> EXTENDS @<D> {:p [2]} on { <sxBCDExxxxxx> <p> 0, 2 }",
           "status": "mf:proposed"
         },
         {
@@ -19660,6 +19672,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "<E> EXTENDS @<D> {:p [2]} on { <sABxDExxxxxx> <p> 0, 2 }",
           "status": "mf:proposed"
         },
         {
@@ -19676,6 +19689,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "<E> EXTENDS @<D> {:p [2]} on { <sABCxExxxxxx> <p> 0, 2 }",
           "status": "mf:proposed"
         },
         {
@@ -19692,6 +19706,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "<E> EXTENDS @<D> {:p [2]} on { <sABCDxxxxxxx> <p> 0, 2 }",
           "status": "mf:proposed"
         },
         {
@@ -19709,6 +19724,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@Extend3G-15",
           "status": "mf:proposed"
         },
         {
@@ -19725,6 +19741,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@Extend3G-16",
           "status": "mf:proposed"
         },
         {
@@ -19741,6 +19758,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@Extend3G-17",
           "status": "mf:proposed"
         },
         {
@@ -19757,6 +19775,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@Extend3G-18",
           "status": "mf:proposed"
         },
         {
@@ -19773,6 +19792,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@Extend3G-19",
           "status": "mf:proposed"
         },
         {
@@ -19789,6 +19809,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@Extend3G-20",
           "status": "mf:proposed"
         },
         {
@@ -19805,6 +19826,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@Extend3G-21",
           "status": "mf:proposed"
         },
         {
@@ -19822,6 +19844,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-22",
           "status": "mf:proposed"
         },
         {
@@ -19838,6 +19861,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-23",
           "status": "mf:proposed"
         },
         {
@@ -19854,6 +19878,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-24",
           "status": "mf:proposed"
         },
         {
@@ -19870,6 +19895,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-25",
           "status": "mf:proposed"
         },
         {
@@ -19886,6 +19912,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-26",
           "status": "mf:proposed"
         },
         {
@@ -19902,6 +19929,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-27",
           "status": "mf:proposed"
         },
         {
@@ -19918,6 +19946,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-28",
           "status": "mf:proposed"
         },
         {
@@ -19934,6 +19963,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-29",
           "status": "mf:proposed"
         },
         {
@@ -19950,6 +19980,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-30",
           "status": "mf:proposed"
         },
         {
@@ -19966,6 +19997,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-31",
           "status": "mf:proposed"
         },
         {
@@ -19982,6 +20014,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-32",
           "status": "mf:proposed"
         },
         {
@@ -19999,6 +20032,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-33",
           "status": "mf:proposed"
         },
         {
@@ -20015,6 +20049,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-34",
           "status": "mf:proposed"
         },
         {
@@ -20031,6 +20066,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@ExtendANDExtend3GAND3G-35",
           "status": "mf:proposed"
         },
         {
@@ -20047,6 +20083,7 @@
           "trait": [
             "Extends"
           ],
+          "comment": "@@vitals-RESTRICTS-36",
           "status": "mf:proposed"
         },
         {
@@ -20064,6 +20101,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-37",
           "status": "mf:proposed"
         },
         {
@@ -20081,6 +20119,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-38",
           "status": "mf:proposed"
         },
         {
@@ -20098,6 +20137,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-39",
           "status": "mf:proposed"
         },
         {
@@ -20115,6 +20155,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-40",
           "status": "mf:proposed"
         },
         {
@@ -20132,6 +20173,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-41",
           "status": "mf:proposed"
         },
         {
@@ -20149,6 +20191,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-42",
           "status": "mf:proposed"
         },
         {
@@ -20166,6 +20209,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-43",
           "status": "mf:proposed"
         },
         {
@@ -20183,6 +20227,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-44",
           "status": "mf:proposed"
         },
         {
@@ -20200,6 +20245,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-45",
           "status": "mf:proposed"
         },
         {
@@ -20217,6 +20263,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-46",
           "status": "mf:proposed"
         },
         {
@@ -20234,6 +20281,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-47",
           "status": "mf:proposed"
         },
         {
@@ -20251,6 +20299,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-48",
           "status": "mf:proposed"
         },
         {
@@ -20268,6 +20317,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-49",
           "status": "mf:proposed"
         },
         {
@@ -20285,6 +20335,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-50",
           "status": "mf:proposed"
         },
         {
@@ -20302,6 +20353,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-51",
           "status": "mf:proposed"
         },
         {
@@ -20319,6 +20371,7 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-52",
           "status": "mf:proposed"
         },
         {
@@ -20336,9 +20389,11 @@
             "Extends",
             "Exhaustive"
           ],
+          "comment": "@@vitals-RESTRICTS-53",
           "status": "mf:proposed"
         }
       ]
     }
   ]
 }
+


### PR DESCRIPTION
Includes old change from main which made sx:shapes take an rdf:Collection of ShapeExprs rather than being a repeated property. Hence the gazillion changed schema/*.ttl changes.