### PR TITLE
~ factor shapeExprOrRef from shapeExpr

### DIFF
--- a/doc/ShExJ.jsg
+++ b/doc/ShExJ.jsg
@@ -15,24 +15,25 @@
 Schema           {
   "@context":"http://www.w3.org/ns/shex.jsonld"?
   imports:[IRIREF+]?
-  startActs:[SemAct+]? start:(shapeExpr | labeledShapeExpr)? shapes:[labeledShapeExpr+]?
+  startActs:[SemAct+]? start:shapeExprOrRef? shapes:[labeledShapeExpr+]?
  }
 
 # labeled Shape Expressions
-labeledShapeExpr        = labeledShapeDecl | labeledShapeOr | labeledShapeAnd | labeledShapeNot | labeledNodeConstraint | labeledShape | shapeExprRef | labeledShapeExternal;
+labeledShapeExpr        = labeledShapeDecl | labeledShapeOr | labeledShapeAnd | labeledShapeNot | labeledNodeConstraint | labeledShape | labeledShapeExternal;
 labeledShapeDecl        { type:"ShapeDecl"      id:shapeExprLabel abstract:BOOL? specializes:[IRIREF+]? shapeExpr:shapeExpr }
-labeledShapeOr          { type:"ShapeOr"        id:shapeExprLabel shapeExprs:[shapeExpr{2,}] }
-labeledShapeAnd         { type:"ShapeAnd"       id:shapeExprLabel shapeExprs:[shapeExpr{2,}] }
-labeledShapeNot         { type:"ShapeNot"       id:shapeExprLabel shapeExpr:shapeExpr }
+labeledShapeOr          { type:"ShapeOr"        id:shapeExprLabel shapeExprs:[shapeExprOrRef{2,}] }
+labeledShapeAnd         { type:"ShapeAnd"       id:shapeExprLabel shapeExprs:[shapeExprOrRef{2,}] }
+labeledShapeNot         { type:"ShapeNot"       id:shapeExprLabel shapeExpr:shapeExprOrRef }
 labeledNodeConstraint   { type:"NodeConstraint" id:shapeExprLabel nodeKind:("iri"|"bnode"|"nonliteral"|"literal")? datatype:IRIREF? xsFacet* values:[valueSetValue+]? }
-labeledShape            { type:"Shape"          id:shapeExprLabel abstract:BOOL? closed:BOOL? extends:[shapeExpr+]? extra:[IRIREF+]? expression:tripleExpr? semActs:[SemAct+]? annotations:[Annotation+]? }
+labeledShape            { type:"Shape"          id:shapeExprLabel closed:BOOL? extends:[shapeExprOrRef+]? extra:[IRIREF+]? expression:tripleExpr? semActs:[SemAct+]? annotations:[Annotation+]? }
 labeledShapeExternal    { type:"ShapeExternal"  id:shapeExprLabel  }
 
 # Shape Expressions
-shapeExpr        = ShapeDecl | ShapeOr | ShapeAnd | ShapeNot | NodeConstraint | Shape | ShapeExternal | shapeExprRef;
-ShapeOr          { shapeExprs:[shapeExpr{2,}] }
-ShapeAnd         { shapeExprs:[shapeExpr{2,}] }
-ShapeNot         { shapeExpr:shapeExpr }
+shapeExpr        = ShapeOr | ShapeAnd | ShapeNot | NodeConstraint | Shape | ShapeExternal;
+shapeExprOrRef   = shapeExpr | shapeExprRef;
+ShapeOr          { shapeExprs:[shapeExprOrRef{2,}] }
+ShapeAnd         { shapeExprs:[shapeExprOrRef{2,}] }
+ShapeNot         { shapeExpr:shapeExprOrRef }
 ShapeExternal    {  }
 shapeExprRef     = shapeExprLabel ;
 shapeExprLabel   = IRIREF | BNODE ;
@@ -59,14 +60,13 @@ LanguageStem     { stem:(LANGTAG | EMPTY) }
 LanguageStemRange{ stem:(LANGTAG | EMPTY | Wildcard) exclusions:[LANGTAG | LanguageStem+] }
 Wildcard         {  }
 
-ShapeDecl        { abstract:BOOL? specializes:[IRIREF+]? shapeExpr:shapeExpr }
-Shape            { abstract:BOOL? closed:BOOL? extends:[shapeExpr+]? extra:[IRIREF+]? expression:tripleExpr? semActs:[SemAct+]? annotations:[Annotation+]? }
+Shape            { abstract:BOOL? closed:BOOL? extends:[shapeExprOrRef+]? extra:[IRIREF+]? expression:tripleExpr? semActs:[SemAct+]? annotations:[Annotation+]? }
 
 # Triple Expressions
 tripleExpr       = EachOf | OneOf | TripleConstraint | tripleExprRef ;
 EachOf           { id:tripleExprLabel? expressions:[tripleExpr{2,}] min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
 OneOf            { id:tripleExprLabel? expressions:[tripleExpr{2,}] min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
-TripleConstraint { id:tripleExprLabel? inverse:BOOL? predicate:IRIREF valueExpr:shapeExpr? min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
+TripleConstraint { id:tripleExprLabel? inverse:BOOL? predicate:IRIREF valueExpr:shapeExprOrRef? min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
 tripleExprRef    = tripleExprLabel ;
 tripleExprLabel  = IRIREF | BNODE ;
 

--- a/doc/ShExJ.jsg
+++ b/doc/ShExJ.jsg
@@ -29,12 +29,11 @@ labeledShape            { type:"Shape"          id:shapeExprLabel closed:BOOL? e
 labeledShapeExternal    { type:"ShapeExternal"  id:shapeExprLabel  }
 
 # Shape Expressions
-shapeExpr        = ShapeOr | ShapeAnd | ShapeNot | NodeConstraint | Shape | ShapeExternal;
+shapeExpr        = ShapeOr | ShapeAnd | ShapeNot | NodeConstraint | Shape;
 shapeExprOrRef   = shapeExpr | shapeExprRef;
 ShapeOr          { shapeExprs:[shapeExprOrRef{2,}] }
 ShapeAnd         { shapeExprs:[shapeExprOrRef{2,}] }
 ShapeNot         { shapeExpr:shapeExprOrRef }
-ShapeExternal    {  }
 shapeExprRef     = shapeExprLabel ;
 shapeExprLabel   = IRIREF | BNODE ;
 NodeConstraint   { nodeKind:("iri"|"bnode"|"nonliteral"|"literal")? datatype:IRIREF? xsFacet* values:[valueSetValue+]? }

--- a/doc/ShExJ.jsg
+++ b/doc/ShExJ.jsg
@@ -25,7 +25,7 @@ labeledShapeOr          { type:"ShapeOr"        id:shapeExprLabel shapeExprs:[sh
 labeledShapeAnd         { type:"ShapeAnd"       id:shapeExprLabel shapeExprs:[shapeExprOrRef{2,}] }
 labeledShapeNot         { type:"ShapeNot"       id:shapeExprLabel shapeExpr:shapeExprOrRef }
 labeledNodeConstraint   { type:"NodeConstraint" id:shapeExprLabel nodeKind:("iri"|"bnode"|"nonliteral"|"literal")? datatype:IRIREF? xsFacet* values:[valueSetValue+]? }
-labeledShape            { type:"Shape"          id:shapeExprLabel closed:BOOL? extends:[shapeExprOrRef+]? extra:[IRIREF+]? expression:tripleExpr? semActs:[SemAct+]? annotations:[Annotation+]? }
+labeledShape            { type:"Shape"          id:shapeExprLabel closed:BOOL? extends:[shapeExprOrRef+]? extra:[IRIREF+]? expression:tripleExprOrRef? semActs:[SemAct+]? annotations:[Annotation+]? }
 labeledShapeExternal    { type:"ShapeExternal"  id:shapeExprLabel  }
 
 # Shape Expressions
@@ -59,12 +59,13 @@ LanguageStem     { stem:(LANGTAG | EMPTY) }
 LanguageStemRange{ stem:(LANGTAG | EMPTY | Wildcard) exclusions:[LANGTAG | LanguageStem+] }
 Wildcard         {  }
 
-Shape            { abstract:BOOL? closed:BOOL? extends:[shapeExprOrRef+]? extra:[IRIREF+]? expression:tripleExpr? semActs:[SemAct+]? annotations:[Annotation+]? }
+Shape            { abstract:BOOL? closed:BOOL? extends:[shapeExprOrRef+]? extra:[IRIREF+]? expression:tripleExprOrRef? semActs:[SemAct+]? annotations:[Annotation+]? }
 
 # Triple Expressions
-tripleExpr       = EachOf | OneOf | TripleConstraint | tripleExprRef ;
-EachOf           { id:tripleExprLabel? expressions:[tripleExpr{2,}] min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
-OneOf            { id:tripleExprLabel? expressions:[tripleExpr{2,}] min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
+tripleExpr       = EachOf | OneOf | TripleConstraint ;
+tripleExprOrRef  = tripleExpr | tripleExprRef ;
+EachOf           { id:tripleExprLabel? expressions:[tripleExprOrRef{2,}] min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
+OneOf            { id:tripleExprLabel? expressions:[tripleExprOrRef{2,}] min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
 TripleConstraint { id:tripleExprLabel? inverse:BOOL? predicate:IRIREF valueExpr:shapeExprOrRef? min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
 tripleExprRef    = tripleExprLabel ;
 tripleExprLabel  = IRIREF | BNODE ;

--- a/doc/ShExJ.jsg
+++ b/doc/ShExJ.jsg
@@ -25,7 +25,7 @@ labeledShapeOr          { type:"ShapeOr"        id:shapeExprLabel shapeExprs:[sh
 labeledShapeAnd         { type:"ShapeAnd"       id:shapeExprLabel shapeExprs:[shapeExprOrRef{2,}] }
 labeledShapeNot         { type:"ShapeNot"       id:shapeExprLabel shapeExpr:shapeExprOrRef }
 labeledNodeConstraint   { type:"NodeConstraint" id:shapeExprLabel nodeKind:("iri"|"bnode"|"nonliteral"|"literal")? datatype:IRIREF? xsFacet* values:[valueSetValue+]? }
-labeledShape            { type:"Shape"          id:shapeExprLabel closed:BOOL? extends:[shapeExprOrRef+]? extra:[IRIREF+]? expression:tripleExpr? semActs:[SemAct+]? annotations:[Annotation+]? }
+labeledShape            { type:"Shape"          id:shapeExprLabel closed:BOOL? extends:[shapeExprOrRef+]? extra:[IRIREF+]? expression:tripleExprOrRef? semActs:[SemAct+]? annotations:[Annotation+]? }
 labeledShapeExternal    { type:"ShapeExternal"  id:shapeExprLabel  }
 
 # Shape Expressions
@@ -62,9 +62,10 @@ Wildcard         {  }
 Shape            { abstract:BOOL? closed:BOOL? extends:[shapeExprOrRef+]? extra:[IRIREF+]? expression:tripleExpr? semActs:[SemAct+]? annotations:[Annotation+]? }
 
 # Triple Expressions
-tripleExpr       = EachOf | OneOf | TripleConstraint | tripleExprRef ;
-EachOf           { id:tripleExprLabel? expressions:[tripleExpr{2,}] min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
-OneOf            { id:tripleExprLabel? expressions:[tripleExpr{2,}] min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
+tripleExpr       = EachOf | OneOf | TripleConstraint ;
+tripleExprOrRef  = tripleExpr | tripleExprRef ;
+EachOf           { id:tripleExprLabel? expressions:[tripleExprOrRef{2,}] min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
+OneOf            { id:tripleExprLabel? expressions:[tripleExprOrRef{2,}] min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
 TripleConstraint { id:tripleExprLabel? inverse:BOOL? predicate:IRIREF valueExpr:shapeExprOrRef? min:INTEGER? max:INTEGER? semActs:[SemAct+]? annotations:[Annotation+]? }
 tripleExprRef    = tripleExprLabel ;
 tripleExprLabel  = IRIREF | BNODE ;


### PR DESCRIPTION
restrict where `shapeExprRef`s can appear:
``` bnf
shapeExpr        = ShapeOr | ShapeAnd | ShapeNot | NodeConstraint | Shape | ShapeExternal;
shapeExprOrRef   = shapeExpr | shapeExprRef;
```