### PR TITLE
Discriminate IRIREF from BNODE

### DIFF
--- a/doc/ShExJ.jsg
+++ b/doc/ShExJ.jsg
@@ -72,25 +72,37 @@ SemAct           { name:IRIREF code:STRING? }
 Annotation       { predicate:IRIREF object:objectValue }
 
 # Terminals used in productions:
-IRIREF           : (PN_CHARS | '.' | ':' | '/' | '\\' | '#' | '@' | '%' | '&' | UCHAR)* ; # <http://www.w3.org/TR/turtle/#grammar-production-IRIREF> - "<>"s
-BNODE            : '_:' (PN_CHARS_U | [0-9]) ((PN_CHARS | '.')* PN_CHARS)? ; # <http://www.w3.org/TR/turtle/#grammar-production-BLANK_NODE_LABEL>
-BOOL             : "true" | "false" ; # JSON boolean tokens
-INTEGER          : [+-]? [0-9]+ ; # <http://www.w3.org/TR/turtle/#grammar-production-INTEGER>
-DECIMAL          : [+-]? [0-9]* '.' [0-9]+ ; # <http://www.w3.org/TR/turtle/#grammar-production-DECIMAL>
-DOUBLE           : [+-]? ([0-9]+ '.' [0-9]* EXPONENT | '.' [0-9]+ EXPONENT | [0-9]+ EXPONENT) ; # <http://www.w3.org/TR/turtle/#grammar-production-DOUBLE>
+                 # <http://www.w3.org/TR/turtle/#grammar-production-IRIREF> - "<>"s
+IRIREF           : (IRIREF_NO_U | IRIREF_ALL IRIREF_NO_COLON) IRIREF_ALL*;
+                 # <http://www.w3.org/TR/turtle/#grammar-production-BLANK_NODE_LABEL>
+BNODE            : '_:' (PN_CHARS_U | [0-9]) ((PN_CHARS | '.')* PN_CHARS)? ;
+                 # JSON boolean tokens
+BOOL             : "true" | "false" ;
+                 # <http://www.w3.org/TR/turtle/#grammar-production-INTEGER>
+INTEGER          : [+-]? [0-9]+ ;
+                 # <http://www.w3.org/TR/turtle/#grammar-production-DECIMAL>
+DECIMAL          : [+-]? [0-9]* '.' [0-9]+ ;
+                 # <http://www.w3.org/TR/turtle/#grammar-production-DOUBLE>
+DOUBLE           : [+-]? ([0-9]+ '.' [0-9]* EXPONENT | '.' [0-9]+ EXPONENT | [0-9]+ EXPONENT) ;
+                 # <https://tools.ietf.org/search/bcp47>
 LANGTAG          : [a-zA-Z]+ ('-' [a-zA-Z0-9]+)* ;
 STRING           : .* ;
 EMPTY            : '' ;
 
 # Terminals use only in other terminals:
-PN_PREFIX        : PN_CHARS_BASE ((PN_CHARS | '.')* PN_CHARS)? ;
+IRIREF_NO_U      : (PN_CHARS_NO_U | IRIREF_CHARS | ':') ;
+IRIREF_NO_COLON  : (PN_CHARS | IRIREF_CHARS) ;
+IRIREF_ALL       : (PN_CHARS | IRIREF_CHARS | ':') ;
+IRIREF_CHARS     : '.' | '/' | '\\' | '#' | '@' | '%' | '&' | UCHAR ;
 PN_CHARS_BASE    : [A-Z] | [a-z] | [\u00C0-\u00D6] | [\u00D8-\u00F6]
                  | [\u00F8-\u02FF] | [\u0370-\u037D] | [\u037F-\u1FFF]
                  | [\u200C-\u200D] | [\u2070-\u218F] | [\u2C00-\u2FEF]
                  | [\u3001-\uD7FF] | [\uF900-\uFDCF] | [\uFDF0-\uFFFD]
                  | [\u10000-\uEFFFF] ;
-PN_CHARS         : PN_CHARS_U | '-' | [0-9] | '\u00B7' | [\u0300-\u036F] | [\u203F-\u2040] ;
+PN_CHARS         : PN_CHARS_U | PN_CHARS_DIAC ;
+PN_CHARS_NO_U    : PN_CHARS_BASE | PN_CHARS_DIAC ;
 PN_CHARS_U       : PN_CHARS_BASE | '_' ;
+PN_CHARS_DIAC    : '-' | [0-9] | '\u00B7' | [\u0300-\u036F] | [\u203F-\u2040]
 UCHAR            : '\\u' HEX HEX HEX HEX
                  | '\\U' HEX HEX HEX HEX HEX HEX HEX HEX ;
 HEX              : [0-9] | [A-F] | [a-f] ;

--- a/doc/ShExJ.jsg
+++ b/doc/ShExJ.jsg
@@ -73,7 +73,7 @@ Annotation       { predicate:IRIREF object:objectValue }
 
 # Terminals used in productions:
                  # <http://www.w3.org/TR/turtle/#grammar-production-IRIREF> - "<>"s
-IRIREF           : (IRIREF_NO_U | IRIREF_ALL IRIREF_NO_COLON) IRIREF_ALL*;
+IRIREF           : (IRIREF_NO_U | '_' IRIREF_NO_COLON) IRIREF_ALL*;
                  # <http://www.w3.org/TR/turtle/#grammar-production-BLANK_NODE_LABEL>
 BNODE            : '_:' (PN_CHARS_U | [0-9]) ((PN_CHARS | '.')* PN_CHARS)? ;
                  # JSON boolean tokens
@@ -90,19 +90,19 @@ STRING           : .* ;
 EMPTY            : '' ;
 
 # Terminals use only in other terminals:
-IRIREF_NO_U      : (PN_CHARS_NO_U | IRIREF_CHARS | ':') ;
-IRIREF_NO_COLON  : (PN_CHARS | IRIREF_CHARS) ;
-IRIREF_ALL       : (PN_CHARS | IRIREF_CHARS | ':') ;
-IRIREF_CHARS     : '.' | '/' | '\\' | '#' | '@' | '%' | '&' | UCHAR ;
-PN_CHARS_BASE    : [A-Z] | [a-z] | [\u00C0-\u00D6] | [\u00D8-\u00F6]
+IRIREF_NO_U      : (IRIREF_CHARS | ':') ;
+IRIREF_NO_COLON  : (IRIREF_CHARS | '_') ;
+IRIREF_ALL       : (IRIREF_CHARS | ':' | '_') ;
+IRIREF_CHARS     : [!#-9;=?-\u005B\u005Da-z~] | PN_CHARS_EXT | DIACRITICALS | UCHAR ;
+PN_CHARS_BASE    : [A-Z] | [a-z] | PN_CHARS_EXT ;
+PN_CHARS_EXT     : [\u00C0-\u00D6] | [\u00D8-\u00F6]
                  | [\u00F8-\u02FF] | [\u0370-\u037D] | [\u037F-\u1FFF]
                  | [\u200C-\u200D] | [\u2070-\u218F] | [\u2C00-\u2FEF]
                  | [\u3001-\uD7FF] | [\uF900-\uFDCF] | [\uFDF0-\uFFFD]
                  | [\u10000-\uEFFFF] ;
-PN_CHARS         : PN_CHARS_U | PN_CHARS_DIAC ;
-PN_CHARS_NO_U    : PN_CHARS_BASE | PN_CHARS_DIAC ;
+PN_CHARS         : PN_CHARS_U | DIACRITICALS ;
 PN_CHARS_U       : PN_CHARS_BASE | '_' ;
-PN_CHARS_DIAC    : '-' | [0-9] | '\u00B7' | [\u0300-\u036F] | [\u203F-\u2040]
+DIACRITICALS     : '-' | [0-9] | '\u00B7' | [\u0300-\u036F] | [\u203F-\u2040] ;
 UCHAR            : '\\u' HEX HEX HEX HEX
                  | '\\U' HEX HEX HEX HEX HEX HEX HEX HEX ;
 HEX              : [0-9] | [A-F] | [a-f] ;

--- a/doc/ShExV.jsg
+++ b/doc/ShExV.jsg
@@ -19,7 +19,7 @@ error            = MissingProperty | TypeMismatch | Failure;
 MissingProperty  { property:IRI valueExpr:NodeConstraint? } # get rid of valueExpr?
 TypeMismatch     { triple:TestedTriple constraint:TripleConstraint errors:[STRING]  }
 NodeTest         { node:(IRI|BNODE|ObjectLiteral) shape:(IRI|BNODE) shapeExpr:shapeExpr }
-ShapeTest        { node:(IRI|BNODE) shape:IRI solution:tripleExprSolutions? startActs:[SemAct+]? annotations:[Annotation+]? }
+ShapeTest        { node:(IRI|BNODE) shape:(IRI|BNODE|START) solution:tripleExprSolutions? startActs:[SemAct+]? annotations:[Annotation+]? }
 SolutionList     { solutions:[shapeExprTest+] }
 FailureList      { errors:[error+] }
 tripleExprSolutions = EachOfSolutions | OneOfSolutions | TripleConstraintSolutions ;
@@ -96,4 +96,4 @@ UCHAR            : '\\u' HEX HEX HEX HEX
                  | '\\U' HEX HEX HEX HEX HEX HEX HEX HEX ;
 HEX              : [0-9] | [A-F] | [a-f] ;
 EXPONENT 	 : [eE] [+-]? [0-9]+ ;
-
+START            : '_: -start-' ;


### PR DESCRIPTION
I'm not sure what the JSON-LD rules are for recognizing a BNode. The playground suggests that it's [anything starting with "_:"](https://json-ld.org/playground/#startTab=tab-nquads&json-ld=%7B%22%40context%22%3A%7B%22p1%22%3A%7B%22%40id%22%3A%22http%3A%2F%2Fa.example%2Fp1%22%2C%22%40type%22%3A%22%40id%22%7D%2C%22p2%22%3A%7B%22%40id%22%3A%22http%3A%2F%2Fa.example%2Fp2%22%2C%22%40type%22%3A%22%40id%22%7D%7D%2C%22%40id%22%3A%22_%3A!%40%23%24%25%5E%26*()%3C%3E%7B%7D~%60%3B'%20asdf%22%2C%22p1%22%3A%22_%3A!%40%23%24%25%5E%26*()%3C%3E%7B%7D~%60%3B'%20asdf%22%2C%22p2%22%3A%22_%3A!%40%23%24%25%5E%26*()%3C%3E%7B%7D~%60%3B%20asdf%22%7D):
``` JSON
{ "@context": {
    "p1": { "@id": "http://a.example/p1", "@type": "@id"},
    "p2": { "@id": "http://a.example/p2", "@type": "@id"} },
  "@id": "_:!@#$%^&*()<>{}~`;' asdf",
  "p1": "_:!@#$%^&*()<>{}~`;' asdf",
  "p2": "_:!@#$%^&*()<>{}~`; asdf"
}
```
``` turtle
_:b0 <http://a.example/p1> _:b0 .
_:b0 <http://a.example/p2> _:b0 .
```
In this PR, I tweaked the JSG to ensure that IRIREF and BNODE are disjoint.

tagging @afs as he may be interested in the JSON-LD aspects